### PR TITLE
Tls certificates check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 CAVALIBA - CMT Monitor 
 ======================
 
-(c) Cavaliba.com 2020 - Version 1.0.0.RC - 2020/11/24 - NOT PRODUCTION READY
+(c) Cavaliba.com 2020 - Version 1.0.0 - 2020/11/29
 
 CMT Monitor is a simple software agent to  :
 
@@ -480,6 +480,8 @@ REVISION
     2020-11-17 - 1.0.alpha - not production ready
 
     2020-11-24 - 1.0.0.RC - new configuration structure
+
+    2020-11-29 - 1.0.0
 
 
 COPYRIGHT

--- a/ansible/cmt_monitor/cmt.py
+++ b/ansible/cmt_monitor/cmt.py
@@ -1,774 +1,217 @@
 #!/usr/bin/python3
-# Cavaliba - 2020 - CMT_monitor - cmt.py
+# cavaliba.com - 2020 - CMT_monitor - cmt.py 
+
 
 import os
-import socket
 import sys
 import time
 import datetime
-import argparse
 import signal
-import yaml
-import json
-import re
+#import re
 
 import psutil
 import requests
 
-# ---
-
-MAX_EXECUTION_TIME=50
-HOME_DIR = os.path.dirname(__file__)
-
-RATE_LIMIT_FILE = os.path.join(HOME_DIR, "alert.last")
-
-# ---
-
-ARGS={}
-CONF={}
-SESSION = requests.session()
+# global variables
+import cmt_globals as cmt
 
 
 
-# ----------------------------------------------------------
-# logit
-# ----------------------------------------------------------
-class bcolors:
-    HEADER = '\033[95m'
-    OKBLUE = '\033[94m'
-    OKGREEN = '\033[92m'
-    WARNING = '\033[93m'
-    FAIL = '\033[91m'
-    ENDC = '\033[0m'
-    BOLD = '\033[1m'
-    UNDERLINE = '\033[4m'
+# shared functions and class
+from cmt_shared import logit, debug, abort, bcolors
+from cmt_shared import parse_arguments
+from cmt_shared import load_conf
+from cmt_shared import display_version, display_modules
+from cmt_shared import pager_test
+from cmt_shared import is_module_active_in_conf
+from cmt_shared import is_module_allowed_in_args
+from cmt_shared import is_timeswitch_on
 
+from cmt_shared import Report, Check, CheckItem
+from cmt_shared import Persist
 
-def logit(line):
-    now = datetime.datetime.today().strftime("%Y/%m/%d - %H:%M:%S")
-    print(now + ' : ' + line)
-
-def debug(*items):
-    if ARGS['debug']:
-        print('DEBUG:',' '.join(items))
-
-# ----------------------------------------------------------
+# ------------
 # Timeout stop
-# ----------------------------------------------------------
+# ------------
 def signal_handler(signum, frame):
-    raise Exception("Timed out!")
-    exit()
-
-# ----------------------------------------------------------
-# Args on CLI
-# ----------------------------------------------------------
-def parse_arguments():
-
-    parser = argparse.ArgumentParser(description='CMT - Cavaliba Monitoring')
-
-    #parser.add_argument('--conf', dest="config_file", type=str ,help="configuration file")
-    parser.add_argument('--report', help='send data to Graylog/Gelf servers', 
-        action='store_true', required=False)
-    parser.add_argument('--alert', help='send alerts to Teams', 
-        action='store_true', required=False)
-    parser.add_argument('--teamstest', help='send test message to teams and exit', 
-        action='store_true', required=False)
-    parser.add_argument('--checkconfig', help='checkconfig and exit', 
-        action='store_true', required=False)
-    parser.add_argument('--debug', help='verbose/debug output', 
-        action='store_true', required=False)
-    parser.add_argument('modules', nargs='*',  
-        action='append', help='modules to check')
-
-    return vars(parser.parse_args())
-
-
-def is_check_in_args(name):
-
-    modules = ARGS['modules'][0]
-    if name in modules  or len(modules) == 0 :
-        return True
-    debug(name, "check not in ARGS")
-    return False
-
-# ------------------------------------------------------------
-# Config
-# ------------------------------------------------------------
-def load_conf():
-
-    # conf.yml
-    config_file = os.path.join(HOME_DIR, "conf.yml")
-    conf = load_conf_file (config_file)
-
-    # conf.d/*/yml  to ease ansible deployment
-    config_dir = os.path.join(HOME_DIR, "conf.d")
-
-    for item in os.scandir(config_dir):
-        if item.is_file(follow_symlinks=False):
-            if item.name.endswith('.yml'):
-                debug("Config File : ",item.path)
-                conf2 = load_conf_file (item.path)
-                if conf2:
-                    conf = merge_conf (conf, conf2)
-
-    debug("DEBUG - Configuration loaded")
-    debug(json.dumps(conf, indent=2))
-    
-    return conf
-
-# -----------
-# load a single file
-def load_conf_file(config_file):
-    
-    with open(config_file) as f:
-        conf = yaml.load(f, Loader=yaml.FullLoader)
-        #print(CONF)
-        #print(json.dumps(CONF, indent=2))
-    return conf
-
-# -----------
-# merge to config : concat keys and merge lists values only
-def merge_conf(conf, conf2):
-    res = conf 
-    for key, value in conf2.items():
-       if key in conf and key in conf2:
-            if isinstance(value, list):
-                # merge :
-                for item in value:
-                    res[key].append(item)
-                # or else keep value from first conf
-    return res
-
-# -----------
-def get_conf_or_default(key, default):
-    if key in CONF:
-        return CONF[key]
-    else:
-        return default
-
-
-def is_check_in_conf(name):
-    if 'checks' in CONF:
-        if name in CONF['checks']:
-            return True
-    debug(name, "not in conf")
-    return False
-
-
-def is_check_active(name):
-    # check in conf
-    if is_check_in_conf(name) and is_check_in_args(name):
-            return True
-    debug(name, "check not active")
-    return False
-
-# ------------------------------------------------------------
-# TEAMS
-# ------------------------------------------------------------
-def teams_send(url=None, color="0000FF",title="CMT Alert", message="n/a", origin="n/a"):
-
-    message = """
-{{
-    "@type": "MessageCard",
-    "@context": "http://schema.org/extensions",
-    "summary": "Monitoring",
-    "themeColor": "{}",
-    "sections": [{{
-        "activityTitle": "{}",
-        "activitySubtitle": "{}",
-        "activityText": "{}",
-        "markdown": false
-    }}],
-}}
-""".format(color, title, origin, message)
-
-
-    headers = {
-        'Content-Type' : 'application/json'
-    }
-
-    try:
-        r = requests.post(url,headers=headers, data=message)
-        return r.status_code
-    except:
-        return 0
-
-
-def teams_geturl(channel="test"):
-    url = ""
-    for item in CONF['teams_channel']:
-        if item['name'] == channel:
-            url = item['url']
-    return url
-
-
-def teams_test():
-    url = teams_geturl(channel="test")
-    origin = CONF['cmt_group'] + '/' + CONF['cmt_node']
-    color="0000FF"
-    title = "TEST TEST from " + origin
-    message = "Test message from CMT. Please ignore."
-    r = teams_send(url=url, title=title, message=message ,color=color, origin=origin)
-    logit("Teams test : " + str(r) )
-
-# ------------------------------------------------------------
-# ALERT rate limit
-# ------------------------------------------------------------
-
-def get_last_send():
-
-    t = 0
-    #if os.path.isfile(RATE_LIMIT_FILE) :
-
-    try:
-        file = open(RATE_LIMIT_FILE,"r")
-        t = int(file.readline())
-        file.close()
-    except:
-        t = 0
-
-    return t
-
-def set_last_send(t):
-
-    try:
-        file = open(RATE_LIMIT_FILE,"w")
-        file.write(str(t))
-        file.close()
-    except:
-        pass
-    return
-
-
-
-# ------------------------------------------------------------
-# GRAYLOG / GELF
-# ------------------------------------------------------------
-def send_graylog_http_gelf(url, data=""):
-    
-    headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
-
-    try:
-        r = SESSION.post(url, data=data, headers=headers)    
-        debug("Message sent to graylog(http/gelf) : " + str(r.status_code))
-    except:
-        logit("Error - couldn't send graylod message (http/gelf) to " + str(url))
-
-def send_graylog_udp_gelf(host, port=12201, data=""):
-
-    #data = '"demo":"42"'
-    #mess = '{ "version":"1.1", "host":"host-test", "short_message":"CMT gelf test", ' + data + ' }'  
-
-    binpayload = bytes(str(data),"utf-8")
-
-    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    server_address = (host, port)
-
-    try:
-        sent = sock.sendto(binpayload, server_address)
-        sock.close()
-        debug("Message sent to graylog(udp/gelf)")
-    except:
-        logit("Error - couldn't send graylod message (udp/gelf) to " + str(host))
-
-# ----------------------------------------------------------
-# class
-# ----------------------------------------------------------
-
-class CheckItem():
-
-    ''' Store one single data point with optional status/alert/info.'''
-
-    def __init__(self, name, value, description=""):
-        self.name = name
-        self.value = value
-        self.description = description
-
-        self.alert = False
-        self.alert_message = ""
-        self.unit = ""
-
-    # ex.
-    # load1, load5 ...
-    
-
-class Check():
-
-    '''Stores multiple checkItem related to a single Check function.
-       Each Check is sent as one message to  a metrology server like Graylog/Elastic.
-       Holds alerts for each check item.
-       Alerts are sent globally at the Report level.
-    '''
-
-    def __init__(self, checkname="unknown", info="n/a"):
-
-        self.checkname = checkname
-        self.info = info
-
-        try:
-            self.group = CONF['cmt_group']
-        except:
-            self.group = 'unknown'
-
-        try:
-            self.node = CONF['cmt_node']
-        except:
-            self.node = 'unknown'
-        
-
-        self.checkitems=[]
-        self.lines=[]
-        
-        self.alert = 0
-
-
-    def add_item(self, item):
-
-        ''' add a CheckItem instance to the Check items list '''
-
-        self.checkitems.append(item)
-        
-        if item.alert:
-            self.alert += 1
-
-
-    def build_graylog_message(self):
-
-
-        graylog_data = '"version":"1.1",' 
-        #graylog_data += '"host":"{}",'.format(self.node)
-        graylog_data += '"host":"{}_{}",'.format(self.group,self.node)
-
-        graylog_data += '"short_message":"cmt_check {}",'.format(self.checkname)
-
-        for item in self.checkitems:
-            graylog_data += '"cmt_{}":"{}",'.format(item.name, item.value)
-            debug("DEBUG - build graylog data : ", str(item.name), str(item.value))
-
-        if self.alert > 0:
-            has_alert = "yes"
-        else:
-            has_alert= "no"
-        graylog_data += '"cmt_alert":"{}",'.format(has_alert)
-
-        graylog_data += '"cmt_group":"{}",'.format(self.group)
-        graylog_data += '"cmt_node":"{}",'.format(self.node)
-        graylog_data += '"cmt_check":"{}",'.format(self.checkname)
-
-        graylog_data = '{' + graylog_data + '}'
-        return graylog_data
-
-
-    def print_to_cli(self):
-
-        print()
-        print(bcolors.OKBLUE + bcolors.BOLD + "Check", self.checkname, bcolors.ENDC)
-
-        for i in self.checkitems:    
-            print("{:20} {:15} - {}".format(i.name, i.value, i.description))
-        
-
-    def send_to_server(self):
-
-        if ARGS["report"]:
-            message = "cmt - " + self.checkname
-            graylog_data = self.build_graylog_message()  
-            
-            for item in CONF['graylog_udp_gelf_servers']:
-                host=item['host']
-                port=item['port']
-                send_graylog_udp_gelf(host=host, port=port, data=graylog_data)
-
-            for item in CONF['graylog_http_gelf_servers']:
-                url=item['url']
-                send_graylog_http_gelf(url=url, data=graylog_data)
-
-
-class Report():
-    
-    '''A Rport stores all the Checks from a single run of CMT.
-    Alerts are sent to Teams/... at the end of the Report
-    '''
-
-    def __init__(self):
-
-        self.checks = []
-        self.alert = 0
-
-
-    def add_check(self, c):
-
-        self.checks.append(c)
-        self.alert += c.alert
-
-
-    def print_alerts_to_cli(self):
-
-        print()
-
-        if self.alert == 0:
-            print(bcolors.OKGREEN + bcolors.BOLD + "No alerts.", bcolors.ENDC)
-        else:
-
-            print(bcolors.FAIL + bcolors.BOLD + "Alerts :", bcolors.ENDC)
-            print('--------')
-            for c in self.checks:
-                for i in c.checkitems:
-                    if i.alert:
-                        print (i.alert_message)
-        print()
-
-
-    def send_alerts(self):
-
-        ''' Send alerts to Teams channels '''
-
-        # check if alert exists
-        if self.alert == 0:
-            debug("Alerts : no alerts to be sent.")
-            return
-
-        # check rate_limit
-        t1 = int(get_last_send())
-        t2 = int(time.time())
-        rate = int(get_conf_or_default("teams_rate_limit",3600))
-
-        if t2-t1 <= rate:
-            logit("Alerts : too many alerts (rate-limit) - no alert sent to Teams")
-            return
-
-        # get alert channel
-        url = teams_geturl(channel="alert")
-        if len(url) == 0:
-            logit("Alerts : no 'alert' channel - no alert sent to Teams")
-            return
-
-
-        # prepare message
-        origin = CONF['cmt_group'] + '/' + CONF['cmt_node']
-        color = "FF0000"
-        title = "ALERT from " + origin
-        
-        message = ""
-        for c in self.checks:
-            for i in c.checkitems:
-                if i.alert:
-                    message += i.alert_message
-                    message += '<br>\n'
-        debug("MESSAGE : ",message)              
-        
-        # send alert
-        r = teams_send(url=url, title=title, message=message ,color=color, origin=origin)
-        if r == 200:
-            logit("Alerts : alert sent to Teams ")
-        else:
-            logit("Alerts : couldn't send alert to Teams - response  " + str(r))
-
-        # update rate_limit
-        set_last_send(t2)
-
-
-# =====================================================================
-# Checks functions
-# =====================================================================
-
-def check_load():
-    
-    c = Check(checkname='load')
-
-    # (1.17, 0.86, 0.52)
-    load = os.getloadavg()
-
-    l1  = CheckItem('load1',load[0])
-    l1.description ='CPU Load Average, one minute'
-    c.add_item(l1)
-
-    l5  = CheckItem('load5',load[1])
-    l5.description='CPU Load Average, 5 minutes'
-    c.add_item(l5)
-
-    l15 = CheckItem('load15',load[2])
-    l15.description='CPU Load Average, 15 minutes'
-    c.add_item(l15)
-    
-    return c
-
-
-def check_cpu():
-
-    '''Get CPU percentage. No alert. Send cpu float value.'''
-
-    c = Check(checkname='cpu') 
-    cpu = psutil.cpu_percent(interval=2)
-
-    i  = CheckItem('cpu',cpu,"CPU Percentage")   
-    c.add_item(i)
-
-    return c
-
-
-def check_memory():
-
-    '''Collect memory percent, used, free, available'''
-
-    c = Check(checkname='memory') 
-      
-    # svmem(total=2749374464, available=1501151232, percent=45.4, used=979968000, 
-    # free=736043008, active=1145720832, inactive=590102528, buffers=107663360, 
-    # cached=925700096, shared=86171648)
-    
-    memory = psutil.virtual_memory()
-    
-    m1  = CheckItem('memory_percent',memory.percent,"Memory used (percent)")
-    c.add_item(m1)
-
-    m2  = CheckItem('memory_used',memory.used,"Memory used (bytes)")
-    c.add_item(m2)
-
-    m3  = CheckItem('memory_available',memory.available,"Memory available (bytes)")
-    c.add_item(m3)
-
-    return c
-
-
-def check_swap():
-
-    c = Check(checkname='swap') 
-    # sswap(total=2147479552, used=0, free=2147479552, percent=0.0, sin=0, sout=0)
-    swap = psutil.swap_memory()
-
-    m1 = CheckItem('swap_percent',swap.percent,"Swap used (percent)")
-    c.add_item(m1)
-
-    m2 = CheckItem('swap_used',swap.used,'Swap used (bytes)')
-    c.add_item(m2)
-
-    return c
-
-def check_boottime():
-
-    c = Check(checkname='boottime') 
-    boottime = int( time.time() - psutil.boot_time() )
-    days = int (boottime / 86400)
-
-    m1 = CheckItem('boottime',boottime,"Seconds since last reboot")
-    c.add_item(m1)
-
-    m2 = CheckItem('boottime_days',days,'Days since last reboot')
-    c.add_item(m2)
-
-    return c
-
-
-# instance checks from list
-
-def check_mounts(item):
-    c = Check(checkname='mount') 
-    return c
-
-
-def check_disks(item):
-
-    c = Check(checkname='disk') 
-    path = item['path']
-    alert_threshold = int(item['alert'])
-
-    # sdiskusage(total=21378641920, used=4809781248, free=15482871808, percent=22.5)
-    disk=psutil.disk_usage(path)
-
-    ci = CheckItem('disk',path,"Path")
-    c.add_item(ci)
-
-    ci = CheckItem('disk_total',disk[0],"Total (Bytes)")
-    c.add_item(ci)
-
-    ci = CheckItem('disk_free',disk[2],"Free (Bytes)")
-    c.add_item(ci)
-
-    ci = CheckItem('disk_percent',disk[3],"Used (percent)")
-    if disk[3] > alert_threshold:
-        ci.alert=True
-        ci.alert_message = "check_disk for {} - critical capacity alert ({} %)".format(path,disk[3])
-    c.add_item(ci)
-
-    return c
-
-
-def check_urls(item):
-
-    c = Check(checkname='url') 
-
-    name = item['name']
-    url = item['url']
-    pattern = item['pattern']
-    
-    ci = CheckItem('url',name,'')
-    c.add_item(ci)
-
-
-    try:
-        resp = requests.get(url, timeout=3)
-    except:
-        #alert_add("check_url - {} - no response to query".format(name))
-        ci = CheckItem('url_status','nok','')
-        ci.description = 'no response to query'
-        c.add_item(ci) 
-        return c
-
-    if resp.status_code != 200:
-        ci = CheckItem('url_status','nok','')
-        ci.description = 'bad response code : ' + str(resp.status_code)
-        ci.alert = True
-        ci.alert_message =  "check_url - {} - bad http code response ({})".format(name,resp.status_code)
-        c.add_item(ci) 
-        return c
-
-    # check pattern
-    mysearch = re.search(pattern,resp.text)
-    if not mysearch:
-        ci = CheckItem('url_status','nok','')
-        ci.description = 'expected pattern not found'
-        ci.alert=True
-        ci.alert_message = "check_url - {} - expected pattern not found.".format(name)
-        c.add_item(ci) 
-        return c
-
-    ci = CheckItem('url_status','ok','')
-    c.add_item(ci) 
-
-    return c
-
-# --------------
-# Checks - TODO
-# --------------
-
-# check_process
-# check_path_exists
-# check_socket_listen
-# check_tcp_socket
-# check_ping
-
-# check_mount
-# check_ntp
-# check_file_count
-
-
-# check_systemctl_status
-
-# check_dir_size
-# check_file_count
-# check_file_age
-# check_file_content
-# check_line_in_file
-# check_apache_status
-# check_fpm_ping
-# check_fpm_status
-# check_redis
-# check_nfs
-# check_mysql
-
-# check_lastlog
-# check_account
-
-# check_sql_query
-# check_elastic_query
-# check_external_script
-
-
-    #tcp=psutil.net_connections(kind='tcp4')
-
-
-    # sdiskpart(device='/dev/sda1', mountpoint='/', fstype='ext4', 
-    #               opts='rw,relatime,errors=remount-ro,data=ordered')
-    # partitions=psutil.disk_partitions(all=False)
-
-    #users = psutil.users()
-    #[suser(name='giampaolo', terminal='pts/2', host='localhost', started=1340737536.0, pid=1352),
-    #    suser(name='giampaolo', terminal='pts/3', 
-    #             host='localhost', started=1340737792.0, pid=1788)]
-
-    #{'name': 'python3', 'cpu_times': pcputimes(user=0.39, system=0.3, 
-    #    children_user=0.0, children_system=0.0), 
-    #    'memory_info': pmem(rss=27049984, vms=123904000, shared=13443072, text=3883008, 
-    #    lib=0, data=13901824, dirty=0), 'username': 'phil', 'pid': 3125}
-    #for proc in psutil.process_iter(['pid', 'name', 'username','cpu_times','memory_info']):
-    #     #print(proc.info)
-
-
-
-# =====================================================================
-# MAPs : map Check names to python functions
-# =====================================================================
-
-CHECK_MAP = {
-    "load"     : check_load,
-    "cpu"      : check_cpu,
-    "memory"   : check_memory,
-    "swap"     : check_swap,
-    "boottime" : check_boottime,
-
-}
-
-CHECK_MAP_MULTIPLE = {
-    "mounts"    : check_mounts,
-    "disks" : check_disks,
-    "urls" : check_urls,
-}
-
-
-# =====================================================================
+    #raise Exception("Timed out!")
+    print("Timed out ! (max_execution_time)")
+    sys.exit()
+
+# ------------
+# Main entry
+# ------------
 
 if __name__=="__main__":
 
+
+    
+    cmt.ARGS = parse_arguments()    
+
+    if cmt.ARGS["version"]:
+        display_version()
+        sys.exit()
+
+    # conf.yml and conf.d/*.yml and remote conf (url)
+    cmt.CONF = load_conf()
+
+
+    maxexec = cmt.CONF['global'].get("max_execution_time", cmt.MAX_EXECUTION_TIME)
     # set global timer to limit global duration
     signal.signal(signal.SIGALRM, signal_handler)
-    signal.alarm(MAX_EXECUTION_TIME)   #  seconds
-    
-    print()
-    logit(bcolors.BOLD + "CMT Stating" + bcolors.ENDC)
-    print('-' * 36)
+    signal.alarm(maxexec)   #  seconds
 
 
-    ARGS = parse_arguments()    
+    # Persist
+    cmt.PERSIST = Persist(file=cmt.DEFAULT_PERSIST_FILE)
 
-    # conf.yml and conf.d/*.yml
-    CONF = load_conf()
+    # print("cmt_last_run :", cmt.PERSIST.has_key("cmt_last_run"))
+    lastrun = cmt.PERSIST.get_key("cmt_last_run", 0)
+    # print("cmt_mast_run :", lastrun)
+    # cmt.PERSIST.set_key("cmt_last_run",int(time.time()))
+    # cmt.PERSIST.save()
+    # sys.exit()
 
-    # TODO : check config option
+    # check config option
+    if cmt.ARGS["checkconfig"]:
+        logit("config OK. use --debug to see full config.")
+        sys.exit()
 
+    # test if global run is enabled
+    tmp = cmt.CONF.get('enabled','yes')
+    if not is_timeswitch_on(tmp):
+        logit("CMT disabled by global configuration.")
+        sys.exit()
 
     # Send test message to Teams
-    if ARGS["teamstest"]:
-        teams_test()
-        exit()
+    if cmt.ARGS["pagertest"]:
+        pager_test()
+        sys.exit()
 
     # TODO : list modules
+    if cmt.ARGS["listmodules"]:
+        display_modules()
+        sys.exit()
+
+
+    # -----------------
+
+    print('-' * 60)
+    display_version()
+    print('-' * 60)
+    logit("Starting ...")
+
+    print("cmt_group      : ", cmt.CONF['global']['cmt_group'])
+    print("cmt_node       : ", cmt.CONF['global']['cmt_node'])
+
+    print()
+    if cmt.ARGS['short']:
+        print("Short output")
+        print("------------")
+        print()
 
 
     report = Report()
 
-    # single checks
-    for key in CHECK_MAP:
-        if is_check_active(key):        
-            check = CHECK_MAP[key]()
-            check.print_to_cli()
-            check.send_to_server()
-            report.add_check(check)
+    # check master switch / CMT disabled ?
+    ts_global_enable = cmt.CONF['global'].get('enable', 'no')
+    if not is_timeswitch_on(ts_global_enable):
+        logit("CMT globally disabled by conf")
+        sys.exit()
 
-    # multiple checks (list of items in conf)
-    for key in CHECK_MAP_MULTIPLE:
-        if is_check_active(key):        
-            if key in CONF:
-                for item in CONF[key]:
-                    check = CHECK_MAP_MULTIPLE[key](item)
-                    check.print_to_cli()
-                    check.send_to_server()
-                    report.add_check(check)
+    # LOOP over each individual check in CONF
 
-    # alerts
+    for checkname in cmt.CONF['checks']:
+
+        debug("Starting check : ", checkname)
+
+        # get conf for this check
+        checkconf = cmt.CONF['checks'][checkname]
+
+        # get module for this check
+        modulename = checkconf.get('module', "unknown")
+        debug("  module : ", modulename)
+
+        #Is module in GLOBAL MAP ?
+        if not modulename in cmt.GLOBAL_MODULE_MAP:
+            debug("  unknown module in MAP: ", modulename)
+            continue
+
+        # check  enabled in conf ?  (in check or in module)
+        ts_check = checkconf.get('enable', 'n/a')
+        # no info
+        if ts_check == "n/a":
+            # module level ?
+            if not is_module_active_in_conf(modulename):  
+                debug("  module disabled in conf")
+                continue #no
+        elif not is_timeswitch_on(ts_check):
+            debug("  check disabled by conf")
+            continue
+
+        # check if module is filtered in ARGS
+        if not is_module_allowed_in_args(modulename):
+            continue
+
+        # create check object
+        check_result = Check(module=modulename, name=checkname, conf = checkconf)
+
+        # HERE / Future : give check_result the needed Module Conf, Global Conf ...
+
+        # TODO : if --available, call diffrent function
+
+        # ---------------
+        # perform check !
+        # ---------------
+        check_result = cmt.GLOBAL_MODULE_MAP[modulename]['check'](check_result)
+
+
+        # TODO done / no output ; available results only
+        if cmt.ARGS["available"]:
+            break
+
+        # Hysteresis / alert upd & own
+        check_result.hysteresis_filter()
+
+        # apply alert_max_level for this check
+        check_result.adjust_alert_max_level()
+
+        # If pager enabled (at check level), and alert exists : set pager True
+        if check_result.alert > 0:
+            tr =  checkconf.get('enable_pager', "no")
+            if is_timeswitch_on(tr):
+                debug("pager for check ", check_result.get_id())
+                check_result.pager = True
+
+
+        # keep returned Persist structure in check_result
+        cmt.PERSIST.set_key(check_result.get_id(), check_result.persist)
+
+        
+        if cmt.ARGS['short']:
+            check_result.print_to_cli_short()
+        else:
+            check_result.print_to_cli_detail()
+        
+        if cmt.ARGS["report"]:            
+            check_result.send_metrology()
+
+        
+        # add Check to report
+        report.add_check(check_result)
+
+
+
+    # Handle alerts after all modules
+    # --------------------------------
     report.print_alerts_to_cli()
-    if ARGS["alert"]:
-        report.send_alerts()
+
+    if cmt.ARGS["pager"]:
+        report.send_alerts_to_pager()
 
 
+    # Save Persistance
+    cmt.PERSIST.set_key("cmt_last_run",int(time.time()))
+    cmt.PERSIST.save()
 
+    logit("Done.")

--- a/ansible/cmt_monitor/cmt_globals.py
+++ b/ansible/cmt_monitor/cmt_globals.py
@@ -1,0 +1,92 @@
+# cavaliba.com - 2020 - CMT_monitor - cmt.py 
+
+# cmt_globals
+
+import os
+import sys
+import requests
+
+
+from checks.load import check_load
+from checks.cpu import check_cpu
+from checks.memory import check_memory
+from checks.swap import check_swap
+from checks.boottime import check_boottime
+from checks.mount import check_mount
+from checks.disk import check_disk
+from checks.url import check_url
+from checks.process import check_process
+from checks.ping import check_ping
+from checks.folder import check_folder
+
+
+requests.packages.urllib3.disable_warnings()
+SESSION = requests.session()
+
+# -----------------
+VERSION = "CMT - Version 1.0.0 - (c) Cavaliba.com - 2020/11/29"
+
+MAX_EXECUTION_TIME = 50
+
+
+#HOME_DIR = os.path.dirname(__file__)
+# determine if application is a script file or frozen exe from PyInstaller
+if getattr(sys, 'frozen', False):
+    HOME_DIR = os.path.dirname(sys.executable)
+    HOME_DIR = "/opt/cmt"
+elif __file__:
+    HOME_DIR = os.path.dirname(__file__)
+
+
+#RATE_LIMIT_FILE = os.path.join(HOME_DIR, "alert.last")
+
+GRAYLOG_HTTP_TIMEOUT = 5 
+
+# http access to remote url for additional config
+REMOTE_CONFIG_TIMEOUT = 3
+
+# post to Teams
+TEAMS_TIMEOUT = 5
+
+# Hystereis
+# delay before going to alerting state
+DEFAULT_HYSTERESIS_ALERT_DELAY = 120
+# delay before resuming to normal state
+DEFAULT_HYSTERESIS_NORMAL_DELAY = 120
+
+# persist
+DEFAULT_PERSIST_FILE = os.path.join(HOME_DIR, "persist.json")
+
+
+# =====================================================================
+# Checks list & MAPs : map Check names to python functions
+# =====================================================================
+
+GLOBAL_MODULE_MAP = {
+    "load"     : {"check": check_load     },
+    "cpu"      : {"check": check_cpu      },
+    "memory"   : {"check": check_memory   },
+    "swap"     : {"check": check_swap     },
+    "boottime" : {"check": check_boottime },
+    "mount"    : {"check": check_mount    },
+    "disk"     : {"check": check_disk     },
+    "url"      : {"check": check_url      },
+    "process"  : {"check": check_process  },
+    "ping"     : {"check": check_ping     },
+    "folder"   : {"check": check_folder   },
+}
+
+
+# ----------------------------
+# Globals / can be changed
+# ---------------------------
+
+
+ARGS={}
+CONF={}
+PERSIST={}
+
+# can be switched to True if no response during current RUN
+# TODO : move to run-context ...
+GRAYLOG_HTTP_SUSPENDED = False
+

--- a/ansible/cmt_monitor/cmt_shared.py
+++ b/ansible/cmt_monitor/cmt_shared.py
@@ -1,0 +1,1025 @@
+# cavaliba.com - 2020 - CMT_monitor - cmt.py 
+# cmt_shared.py
+#    - common functions, class and structures
+
+
+import os
+import socket
+import sys
+import time
+import datetime
+import argparse
+import yaml
+import json
+
+import requests
+requests.packages.urllib3.disable_warnings()
+
+import cmt_globals as cmt
+from cmt_globals import *
+
+
+# ----------------------------------------------------------
+# logit
+# ----------------------------------------------------------
+class bcolors:
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'
+
+def logit(line):
+    now = datetime.datetime.today().strftime("%Y/%m/%d - %H:%M:%S")
+    print(now + ' : ' + line)
+
+def abort(line):
+    now = datetime.datetime.today().strftime("%Y/%m/%d - %H:%M:%S")
+    print(now + ' : ' + line)
+    print("ABORTING.")
+    sys.exit()
+
+def debug(*items):
+    if cmt.ARGS['debug'] or cmt.ARGS['debug2']:
+        print('DEBUG :',' '.join(items))
+
+def debug2(*items):
+    if cmt.ARGS['debug2']:
+        print('DEBUG2:',' '.join(items))
+
+# ----------------------------------------------------------
+# Helper functions
+# ----------------------------------------------------------
+
+def is_timeswitch_on(myconfig):
+    ''' check if a date/time time range is active
+        myconfig can be :
+              yes
+              no
+              after YYYY-MM-DD hh:mm:ss
+              before YYYY-MM-DD hh:mm:ss
+              hrange  hh:mm:ss hh:mm:ss
+              ho   (Mon-Fri 8h30-18h)
+              hno
+        returns True or False if current datatime match myconfig
+    '''
+
+    # yaml gotcha
+    myconfig = str (myconfig)
+
+    if myconfig == "True" or myconfig == "yes" or myconfig == "true":
+        return True
+
+    if myconfig == "False" or myconfig =="no"  or myconfig == "false":
+        return False
+    
+    myarray = myconfig.split()
+    action = myarray.pop(0)
+    
+    if action  == "after":
+        mynow = datetime.datetime.today().strftime("%Y-%m-%d %H:%M:%S")
+        target = ' '.join(myarray)
+        #print(mynow)
+        if mynow >= target:
+            return True
+        return False
+
+    if action == "before":
+        mynow = datetime.datetime.today().strftime("%Y-%m-%d %H:%M:%S")
+        target = ' '.join(myarray)
+        if mynow <= target:
+            return True
+        return False
+
+    if action == "hrange":
+        mynow = datetime.datetime.today().strftime("%H:%M:%S")
+        if mynow >= myarray[0] and mynow <= myarray[1]:
+            return True
+        return False
+
+    if action == "ho":
+        myday  = datetime.datetime.today().strftime("%a")
+        myhour = datetime.datetime.today().strftime("%H:%M:%S")
+        if myday in ["Sat","Sun"]:
+            return False
+        if myhour < "08:30:00" or myhour > "18:00:00":
+            return False
+        return True
+
+    if action == "hno":
+        myday  = datetime.datetime.today().strftime("%a")
+        myhour = datetime.datetime.today().strftime("%H:%M:%S")
+        if myday in ["Mon","Tue","Wed","Thu","Fri"]:
+            if myhour >= "08:30:00" or myhour <= "18:00:00":
+                return False
+        return True
+
+    # default, unknown / no match
+    return False
+
+# -----------------------------------------------------
+# short commands
+# -----------------------------------------------------
+def display_version():
+    print(cmt.VERSION)
+
+def display_modules():
+    display_version()
+    print()
+    print("Available modules")
+    print("-----------------")
+
+    for key in cmt.GLOBAL_MODULE_MAP:
+        print("  - ", key )
+    
+
+# ----------------------------------------------------------
+# Args on CLI
+# ----------------------------------------------------------
+def parse_arguments():
+
+    parser = argparse.ArgumentParser(description='CMT - Cavaliba Monitoring')
+
+    #parser.add_argument('--conf', dest="config_file", type=str ,help="configuration file")
+    
+    parser.add_argument('--report', help='send events to Metrology servers', 
+        action='store_true', required=False)
+    parser.add_argument('--pager', help='send alerts to Pagers', 
+        action='store_true', required=False)
+    parser.add_argument('--persist', help='persist data accross CMT runs (use in cron)',
+        action='store_true', required=False)
+
+    parser.add_argument('--conf', help='specify alternate yaml config file', 
+        action='store', required=False)
+
+    parser.add_argument('modules', nargs='*',  
+        action='append', help='modules to check')
+    
+    parser.add_argument('--pagertest', help='send test message to teams and exit', 
+        action='store_true', required=False)
+    parser.add_argument('--no-pager-rate-limit', help='disable pager rate limit', 
+        action='store_true', required=False)  
+
+
+    parser.add_argument('--checkconfig', help='checkconfig and exit', 
+        action='store_true', required=False)
+
+    parser.add_argument('--version', '-v', help='display current version', 
+        action='store_true', required=False)
+    parser.add_argument('--debug', help='verbose/debug output', 
+        action='store_true', required=False)
+    parser.add_argument('--debug2', help='more debug', 
+        action='store_true', required=False)
+
+    parser.add_argument('--short','-s', help='short compact cli output', 
+        action='store_true', required=False)
+    parser.add_argument('--devmode', help='dev mode, no pager, no remote metrology', 
+        action='store_true', required=False)    
+
+
+    parser.add_argument('--listmodules', help='display available modules', 
+        action='store_true', required=False)
+    parser.add_argument('--available', help='display available entries found for modules (manual run on target)', 
+        action='store_true', required=False)
+
+
+    return vars(parser.parse_args())
+
+
+# ------------------------------------------------------------
+# Configuration management
+# ------------------------------------------------------------
+
+def load_conf_master():
+
+    debug("Load master conf")
+
+    # TODO : accept config as a parameter, check default locations
+
+    if cmt.ARGS['conf']: 
+        config_file = cmt.ARGS['conf']    
+    else:        
+        config_file = os.path.join(cmt.HOME_DIR, "conf.yml")    
+    
+    debug("Config file : ", config_file)
+
+    if not os.path.exists(config_file):
+        logit('Config file not found : ' + config_file)
+        sys.exit()
+
+    # load master conf
+    conf = conf_load_file(config_file)
+    conf = conf_add_top_entries(conf)
+
+    return conf
+
+
+def load_conf_dirs(conf):
+
+    debug("Load conf dirs")
+
+    # load_confd
+    loadconfd = conf['global'].get("load_confd","no")
+
+    if loadconfd == False or loadconfd =="no" :
+        return conf
+
+    # conf.d/*/yml  to ease ansible or modular configuration
+    config_dir = os.path.join(cmt.HOME_DIR, "conf.d")
+
+    # check if conf.d exists
+    if not os.path.exists(config_dir):
+        debug ("no conf.d/ found. Ignoring.")
+        return conf
+
+    # scan and merge
+    for item in os.scandir(config_dir):
+        if item.is_file(follow_symlinks=False):
+            if item.name.endswith('.yml'):
+                debug2("Additionnal config file found : ",item.path)
+                conf2 = conf_load_file(item.path)
+                conf2 = conf_add_top_entries(conf2)
+                conf = conf_merge(conf, conf2)
+
+    return conf
+
+
+def load_conf_remote(conf):
+
+    debug("Load remote conf")
+    
+    # load remote config from conf_url parameter
+    if 'conf_url' in conf['global']:
+                
+        url = conf['global']['conf_url']
+        gro = conf['global'].get("cmt_group","nogroup")
+        nod = conf['global'].get("cmt_node","nonode")
+    
+        if url[-1] == '/':
+            url = url + "{}_{}.txt".format(gro,nod)
+
+        debug("Remote config URL : ", url)
+
+
+        text_conf2 = conf_load_http(url)
+        conf2 = yaml.safe_load(text_conf2)
+        if conf2 is None:
+            conf2={}
+        conf2 = conf_add_top_entries(conf2)
+        conf = conf_merge(conf, conf2)
+
+    debug("Configuration loaded")
+    debug2(json.dumps(conf, indent=2))
+
+    return conf
+
+
+def load_conf():
+
+    debug("Load conf")
+
+    conf = load_conf_master()
+    conf = load_conf_dirs(conf)
+    conf = load_conf_remote(conf)
+    
+    return conf
+
+# -----------
+def conf_add_top_entries(conf):
+
+    # add missing top entries
+    # TODO : move list to DEFAULTs
+    for item in ['global','modules','checks','metrology_servers', 'pagers']:
+        if not item in conf:
+            debug("No {} entry in config ; added automatically.".format(item))
+            conf[item] = {}
+
+    return conf
+
+# -----------
+# load a single file
+def conf_load_file(config_file):
+    
+    with open(config_file) as f:
+        conf = yaml.load(f, Loader=yaml.SafeLoader)
+        #print(CONF)
+        #print(json.dumps(CONF, indent=2))
+
+    # # verify content  
+    if conf is None:
+        return {}
+    #    abort("Bad config; Exiting.")
+    #     sys.exit()
+
+    return conf
+
+# -----------
+def conf_load_http(url):
+
+        headers = {
+            'Content-Type' : 'application/text'
+        }
+
+        if cmt.ARGS['devmode']:
+            print("DEVMODE : GET ",url,headers)
+
+        # real
+        try:
+            r = requests.get(url,headers=headers, timeout = cmt.REMOTE_CONFIG_TIMEOUT)
+            result = r.text
+        except:
+            result = "---\n"
+        debug("remote conf:",result)
+        return result
+
+# -----------
+def conf_merge(conf1, conf2):
+
+    debug("merge conf ")
+    for topitem in ['global','modules','checks','metrology_servers', 'pagers']:
+        #print("  topitem = ", topitem,  "conf2 = " , conf2[topitem], type)
+        #print (type(conf2[topitem]))
+        for k in conf2[topitem]:
+            #print("k=",k)
+            conf1[topitem][k] = conf2[topitem][k]
+    return conf1
+
+# ------------------
+def is_module_allowed_in_args(name):
+    modules = cmt.ARGS['modules'][0]
+    if name in modules  or len(modules) == 0 :
+        return True
+    debug(name, "module not in ARGS")
+    return False
+
+# ------------------
+def is_module_active_in_conf(module):
+    ''' check if module (name) is enabled in config '''
+
+    if not module in cmt.CONF['modules']:
+        debug("module not in conf :", module)
+        return False
+
+    timerange = cmt.CONF['modules'][module].get("enable", "yes")
+    
+    if is_timeswitch_on(timerange):
+        return True
+    
+    debug("module not enabled in conf : ", module)
+    return False
+
+
+def conf_get_hysteresis(check):
+    ''' return configuration for alert_delay, resume_delay 
+        with inheritance: check, module, global, DEFAULT.
+    '''
+
+    alert_delay = 0
+
+    if "alert_delay" in check.conf:
+        alert_delay = int(check.conf["alert_delay"])
+
+    elif "alert_delay" in cmt.CONF['modules'][check.module]:
+        alert_delay =  int(cmt.CONF['modules'][check.module]['alert_delay'])
+
+    else:
+        alert_delay = cmt.CONF['global'].get("alert_delay", cmt.DEFAULT_HYSTERESIS_ALERT_DELAY)
+
+    return alert_delay
+
+# ------------------------------------------------------------
+#  Pager  TEAMS
+# ------------------------------------------------------------
+def teams_send(url=None, color="0000FF",title="CMT Alert", message="n/a", origin="n/a"):
+
+    message = """
+{{
+    "@type": "MessageCard",
+    "@context": "http://schema.org/extensions",
+    "summary": "Monitoring",
+    "themeColor": "{}",
+    "sections": [{{
+        "activityTitle": "{}",
+        "activitySubtitle": "{}",
+        "activityText": "{}",
+        "markdown": false
+    }}],
+}}
+""".format(color, title, origin, message)
+
+
+    headers = {
+        'Content-Type' : 'application/json'
+    }
+
+    # SEND !
+    if cmt.ARGS['devmode']:
+        print("DEVMODE : ",url,headers,message)
+        return 200
+    # real
+    try:
+        r = requests.post(url,headers=headers, data=message, timeout = TEAMS_TIMEOUT)
+        return r.status_code
+    except:
+        return 0
+
+
+def pager_test():
+
+    pagerconf = cmt.CONF['pagers'].get('test')
+    url = pagerconf.get('url')
+    debug ("pager url :", url)
+
+    origin = cmt.CONF['global']['cmt_group'] + '/' + cmt.CONF['global']['cmt_node']
+    color="0000FF"
+    title = "TEST TEST from " + origin
+    message = "Test message to Teams. Please ignore."
+    if cmt.ARGS['devmode']:
+        # DEVMODE to stdout
+        print("DEVMODE : url=({}), title=({}), message=({}), color=({}), origin=({})".format(url, title, message, color, origin))
+        return
+    # REAL
+    r = teams_send(url=url, title=title, message=message ,color=color, origin=origin)
+    logit("Teams test : " + str(r) )
+
+
+# ------------------------------------------------------------
+# Metrology Servers 
+# ------------------------------------------------------------
+
+
+# GRAYLOG / GELF
+# ---------------
+
+def build_gelf_message(check):
+    '''Prepare a GELF JSON message suitable to be sent to a Graylog GELF server.'''
+
+    graylog_data = '"version":"1.1",' 
+    graylog_data += '"host":"{}_{}",'.format(check.group, check.node)
+
+    # common values
+    graylog_data += '"cmt_group":"{}",'.format(check.group)
+    graylog_data += '"cmt_node":"{}",'.format(check.node)
+
+    graylog_data += '"cmt_node_env":"{}",'.format(check.node_env)
+    graylog_data += '"cmt_node_role":"{}",'.format(check.node_role)
+    graylog_data += '"cmt_node_location":"{}",'.format(check.node_location)
+
+    graylog_data += '"cmt_module":"{}",'.format(check.module)
+    graylog_data += '"cmt_check":"{}",'.format(check.module)    # deprecated
+    graylog_data += '"cmt_id":"{}",'.format(check.get_id())
+
+    # cmt_message  : Check name + check.message + all items.alert_message
+    m ="{} - ".format(check.module)
+    m = m + check.get_message_as_str()
+    graylog_data += '"short_message":"{}",'.format(m)
+    graylog_data += '"cmt_message":"{}",'.format(m)
+    #print("ooo    ",m)
+
+    # check items key/values
+    for item in check.checkitems:
+        graylog_data += '"cmt_{}":"{}",'.format(item.name, item.value)
+        debug("Build gelf data : ", str(item.name), str(item.value))
+
+    # cmt_alert ?
+    if check.alert > 0:
+        has_alert = "yes"
+    else:
+        has_alert= "no"
+    graylog_data += '"cmt_alert":"{}"'.format(has_alert)
+
+    # cmt_warn ?
+    if check.warn > 0:
+        has_warn = "yes"
+    else:
+        has_warn= "no"
+    graylog_data += '"cmt_warning":"{}"'.format(has_warn)
+
+    # cmt_notice ?
+    if check.notice > 0:
+        has_notice = "yes"
+    else:
+        has_notice= "no"
+    graylog_data += '"cmt_notice":"{}"'.format(has_notice)
+
+
+    graylog_data = '{' + graylog_data + '}'
+    
+    return graylog_data
+
+
+
+def graylog_send_http_gelf(url, data=""):
+    
+    headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
+
+    if cmt.GRAYLOG_HTTP_SUSPENDED:
+        logit("suspended - HTTP graylog message (http/gelf) not sent to " + str(url))
+        return
+
+    if cmt.ARGS['devmode']:
+        print("DEVMODE : graylog http : ", url, data, headers)
+        return
+
+    try:
+        r = cmt.SESSION.post(url, data=data, headers=headers, timeout = cmt.GRAYLOG_HTTP_TIMEOUT)    
+        debug("Message sent to graylog(http/gelf) ; status = " + str(r.status_code))
+    except:
+        logit("Error - couldn't send graylog message (http/gelf) to " + str(url))
+        cmt.GRAYLOG_HTTP_SUSPENDED = True
+
+
+def graylog_send_udp_gelf(host, port=12201, data=""):
+
+    #data = '"demo":"42"'
+    #mess = '{ "version":"1.1", "host":"host-test", "short_message":"CMT gelf test", ' + data + ' }'  
+
+
+    if cmt.ARGS['devmode']:
+        print("DEVMODE : graylog udp : ", host, port, data)
+        return
+
+    binpayload = bytes(str(data),"utf-8")
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    server_address = (host, port)
+
+    try:
+        sent = sock.sendto(binpayload, server_address)
+        sock.close()
+        debug("Message sent to graylog(udp/gelf)")
+    except:
+        logit("Error - couldn't send graylod message (udp/gelf) to " + str(host))
+
+
+# ----------------------------------------------------------
+# Class PERSIST
+# ----------------------------------------------------------
+class Persist():
+    ''' Implement a persistent on-disk key/value structure, between cmt runs'''
+
+    def __init__(self, file = None):    
+        self.file = file
+        self.dict = {}
+        self.load()
+
+    def has_key(self,key):
+        return key in self.dict
+
+    def get_key(self,key , value = None):
+        return self.dict.get(key,value)
+
+
+    def set_key(self, key, value):
+        self.dict[key]=value
+
+
+    def delete_key(self,key):
+        self.dict.pop(key, None)
+
+
+    def load(self):
+        debug("Persist.load() : ", self.file)
+        data = ""
+        try:
+            with open(self.file,"r") as fi:
+                data=fi.read()            
+        except:
+            debug("ERROR - Persist() : couldn't read file {}".format(self.file))
+        # decoding the JSON to dictionay
+        try:
+            self.dict = json.loads(data)
+        except:
+            debug("ERROR - Persist() : couldn't decode data")
+
+
+    def save(self):
+
+        if not cmt.ARGS['persist']:
+            debug("Persist.save : disable (cli / no arg)")            
+            return
+
+        debug("Persist.write() : ", self.file)
+        data = json.dumps(self.dict, indent=2)
+        try:
+            with open(self.file,"w") as fi:
+                fi.write(data)
+        except:
+            debug("ERROR - Persist() : couldn't write file {}".format(self.file))
+
+
+    
+
+# ----------------------------------------------------------
+# Class CheckItem
+# ----------------------------------------------------------
+
+class CheckItem():
+
+    ''' Store one single data point '''
+
+    def __init__(self, name, value, description="", unit=''):
+        self.name = name
+        self.value = value
+        self.description = description
+        self.unit = unit
+
+    def fmt_bytes(self,num, suffix='B'):
+        for unit in ['','K','M','G','T','P','E','Z']:
+            if abs(num) < 1000.0:
+                return "%3.1f %s%s" % (num, unit, suffix)
+            num /= 1000.0
+        return "%.1f %s%s" % (num, 'Y', suffix)
+
+    def fmt_hms(self, sec):
+        a = datetime.timedelta(seconds = sec)
+        return str(a)
+
+    def human(self):
+        '''Build an optional ()  human formatted string for some units values'''
+        if self.unit == 'bytes':
+            x = self.fmt_bytes(int(self.value))
+            return str(x)
+        elif self.unit == 'seconds':
+            x = self.fmt_hms(int(self.value))
+            return x
+        else:
+            return ''
+
+    
+# ----------------------------------------------------------
+# Class Check
+# ----------------------------------------------------------
+
+class Check():
+
+    '''class Check():
+       - Stores multiple CheckItem related to a single Check function run.
+       - Each Check is sent as one message to a metrology server like Graylog/Elastic.
+       - Count alerts from CheckItem : alert is sent as Yyes/no if any of the checkItem as an alert.
+       - Pager alerts are sent globally at the Report level.
+    '''
+
+    def __init__(self, module="nomodule", name="noname", conf = {}):
+
+        self.group = cmt.CONF['global'].get('cmt_group','nogroup')
+        self.node = cmt.CONF['global'].get('cmt_node', 'nonode')
+        self.node_env = cmt.CONF['global'].get('cmt_node_env', 'noenv')
+        self.node_role = cmt.CONF['global'].get('cmt_node_role', 'norole')
+        self.node_location = cmt.CONF['global'].get('cmt_node_location', 'nolocation')
+        self.module = module
+        self.name = name
+
+        self.message = []
+
+        self.alert = 0
+        self.warn = 0
+        self.notice = 0
+        self.checkitems=[]    
+
+        # set by framework after Check is performed, if pager_enable and alert>0
+        self.pager = False
+
+        # fields from conf
+        self.conf = conf
+        
+        
+        # persist values from previous run for same get_id()
+        id = self.get_id()
+        self.persist = cmt.PERSIST.get_key(id,{})
+        
+        # compute alert_max_level
+        self.alert_max_level = "alert"   # DEFAULT
+        # check level ?
+        a = conf.get('alert_max_level','')
+        if a in ['alert','notice','warn']:
+            self.alert_max_level = a
+        else:
+            # module level ?
+            b = cmt.CONF['modules'][self.module].get('alert_max_level','')
+            if b in ['alert','notice','warn']:
+                self.alert_max_level = b
+            else:
+                # global level
+                c = cmt.CONF['global'].get('alert_max_level','')
+                if c in ['alert','notice','warn']:
+                    self.alert_max_level = c
+
+
+
+    def add_message(self, m):
+
+        self.message.append(m)
+
+
+    def add_item(self, item):
+        ''' add a CheckItem instance to the Check items list '''
+        self.checkitems.append(item)          
+
+    def get_id(self):
+        ''' Returns unique check id '''
+        return "{}.{}.{}.{}".format(self.group, self.node, self.module, self.name)
+
+    def get_message_as_str(self):
+
+        v = ""
+        for mm in self.message:
+            if len(v) > 0:
+                v = v + " ; "
+            v = v + mm 
+        return v
+
+
+    def adjust_alert_max_level(self, level = ""):
+
+        if level == "":
+            level = self.alert_max_level
+
+        debug("adjust alert_max_level to : ", level)
+
+        if level == "alert":
+            return
+        
+        if level == "warn":
+            self.notice = self.warn
+            self.warn = self.alert
+            self.alert = 0
+            return
+        
+        if level == "notice":
+            self.notice = self.alert
+            self.alert = 0
+            self.warn = 0
+
+
+    def  hysteresis_filter(self):
+
+        ''' Apply Hystereris up/down to alerts for this check :
+            - consecutive alerts (duration) needed to define real alert
+            - consecutire no_alert (idem) needed to define return to noalert
+        '''
+
+        # seconds for state transition normal to alert (if alert)
+        alert_delay = conf_get_hysteresis(self)
+
+        hystpersist = cmt.PERSIST.get_key("hysteresis", {})        
+        id = self.get_id()
+        hystpersist_item = hystpersist.get(id,{})
+
+        hystlastrun = hystpersist_item.get('lastrun',0)
+        now = int(time.time())
+        delta = int ( now - hystlastrun )
+        
+        duration_alert = hystpersist_item.get('duration_alert',0)
+        oldstate = hystpersist_item.get('state','normal')
+        
+        newstate = oldstate
+
+        #print("Hysteresis", duration_alert, delta, alert_delay)
+        
+        if self.alert > 0 :
+            if oldstate == "normal":
+                duration_alert += delta
+                if duration_alert > alert_delay:
+                    # transition to up
+                    debug2("Transition to alert", duration_alert, delta, alert_delay)
+                    newstate = "alert"
+        else:
+            newstate = "normal"
+            duration_alert = 0
+
+        # state transition from normal to alert : real alert ?
+        if newstate == "normal":
+            # adjust to warn ; not a transition
+            self.adjust_alert_max_level("warn")
+
+        # write to Persist   
+        # lastrun   
+        # BUG
+        hystpersist_item['lastrun'] = now
+        hystpersist_item['duration_alert'] = duration_alert
+        hystpersist_item['state'] = newstate
+        hystpersist[id] = hystpersist_item
+        cmt.PERSIST.set_key("hysteresis",hystpersist)
+
+
+
+    def print_to_cli_short(self):
+
+        head = bcolors.OKGREEN     + "OK     " + bcolors.ENDC
+
+        if self.alert > 0:
+            head = bcolors.FAIL    + "NOK    " + bcolors.ENDC
+        elif self.warn > 0:
+            head = bcolors.WARNING + "WARN   " + bcolors.ENDC
+        elif self.notice > 0:
+            head = bcolors.OKBLUE  + "NOTICE " + bcolors.ENDC
+
+        #print(head, self.get_message_as_str())
+        print("{:12} {:10} {}".format(head, self.module, self.get_message_as_str()))
+
+    def print_to_cli_detail(self):
+       
+        print()
+        print(bcolors.OKBLUE + bcolors.BOLD + "Check", self.module, bcolors.ENDC)        
+
+        for i in self.checkitems:    
+
+            v = str (i.value) + ' ' + str(i.unit) + ' (' + i.human() + ') '
+            if len (i.description) > 0:
+                v = v + ' - ' + i.description
+
+            print("cmt_{:18} {}".format(i.name, v))
+        
+
+        head = bcolors.OKGREEN     + "OK     " + bcolors.ENDC
+
+        if self.alert > 0:
+            head = bcolors.FAIL    + "NOK    " + bcolors.ENDC
+        elif self.warn > 0:
+            head = bcolors.WARNING + "WARN   " + bcolors.ENDC
+        elif self.notice > 0:
+            head = bcolors.OKBLUE  + "NOTICE " + bcolors.ENDC
+
+        print("{:31} {}".format(head, self.get_message_as_str()))        
+
+
+    def send_metrology(self):
+        
+        ''' Send Check results (event, multiple CheckItems) 
+            to metrology servers.
+        '''
+
+        graylog_data = build_gelf_message(self)  
+        
+        for metro in cmt.CONF['metrology_servers']:
+
+
+            metroconf = cmt.CONF['metrology_servers'][metro]
+            metrotype = metroconf.get('type', 'unknown')
+
+            timerange = metroconf.get("enable", "yes")
+            if not is_timeswitch_on(timerange):
+                debug("Metrology server disabled in conf : ", metro)
+                return
+
+            if metrotype == "graylog_udp_gelf":
+                host=metroconf['host']
+                port=metroconf['port']
+                graylog_send_udp_gelf(host=host, port=port, data=graylog_data)
+                debug("Data sent to metrology server ", metro)
+
+            elif metrotype == "graylog_http_gelf":
+                url=metroconf['url']
+                graylog_send_http_gelf(url=url, data=graylog_data)
+                debug("Data sent to metrology server ", metro)
+
+            else:
+                debug("Unknown metrology server type in conf.")
+
+# ----------------------------------------------------------
+# Class Report
+# ----------------------------------------------------------
+
+class Report():
+    
+    '''A Report stores all the Checks from a single run of CMT.
+       Pager alerts are sent to Pager targets at the end of the run.
+    '''
+
+    def __init__(self):
+
+        self.checks = []
+        self.alert = 0
+        self.warn = 0
+        self.notice = 0
+
+        self.pager = False
+
+    def add_check(self, c):
+
+        self.checks.append(c)
+        self.alert += c.alert
+        self.warn += c.warn
+        self.notice += c.notice
+
+        # propagate Pager from check to report
+        if c.pager:
+            self.pager = True
+
+    def print_alerts_to_cli(self):
+        ''' print pager/alerts to CLI '''
+
+        print()
+        print("Notification Summary")
+        print("--------------------")
+        print()
+        if self.notice == 0:
+            print(bcolors.OKBLUE + bcolors.BOLD + "No notice", bcolors.ENDC)
+        else:
+            print(bcolors.OKBLUE + bcolors.BOLD + "Notice", bcolors.ENDC)
+            for c in self.checks:
+                    if c.notice > 0:
+                        print ("{:15s} : {}".format(c.module, c.get_message_as_str()))
+
+        print()
+        if self.warn == 0:
+            print(bcolors.OKGREEN + bcolors.BOLD + "No warnings", bcolors.ENDC)
+        else:
+            print(bcolors.WARNING + bcolors.BOLD + "Warnings", bcolors.ENDC)
+            for c in self.checks:
+                    if c.warn > 0:
+                        print ("{:15s} : {}".format(c.module, c.get_message_as_str()))
+        print()
+        if self.alert == 0:
+            print(bcolors.OKGREEN + bcolors.BOLD + "No alerts", bcolors.ENDC)
+        else:
+            print(bcolors.FAIL + bcolors.BOLD + "Alerts", bcolors.ENDC)
+            for c in self.checks:
+                    if c.alert > 0:
+                        print ("{:15s} : {}".format(c.module, c.get_message_as_str()))
+        print()
+
+
+
+    def send_alerts_to_pager(self):
+
+        ''' Send alerts to Pagers '''
+
+        # check if alert exists
+        if not self.pager:
+            debug("Pager : no Pager to be fired")
+            return
+
+        # check if Pager enabled globally (global section, master switch)
+        tmp = cmt.CONF['global'].get("enable_pager", "no")
+        if not is_timeswitch_on(tmp):
+            debug("Pager  : disabled/inactive in global config.")
+            return
+
+        # Find 'Alert' Pager         
+        if not 'alert' in cmt.CONF['pagers']:
+            debug("No alert pager configured.")
+            return
+
+        pagerconf = cmt.CONF['pagers'].get('alert')
+
+        # check if the 'Alert' Pager is enabled
+        tmp2 = pagerconf.get("enable", "no")
+        if not is_timeswitch_on(tmp2):
+            debug("Pager  : alert pager disbled in conf.")
+            return
+
+        # check rate_limit
+        t1 = int (cmt.PERSIST.get_key("pager_last_send", 0))
+        t2 = int(time.time())
+        rate = int (cmt.CONF['global'].get("pager_rate_limit",7200))
+
+        if not cmt.ARGS['no_pager_rate_limit']:
+            if t2-t1 <= rate:
+                logit("Alerts : too many alerts (rate-limit) - no alert sent to Pager")
+                return
+
+        # get Teams alert channel url
+        url = pagerconf.get('url')
+        debug ("pager url :", url)
+
+        # prepare message
+        origin = cmt.CONF['global']['cmt_group'] + '/' + cmt.CONF['global']['cmt_node']
+        color = "FF0000"
+        title = "ALERT from " + origin
+        
+        message = ""
+        for c in self.checks:
+                if c.alert > 0:
+                    message += 'ALERT: '
+                    message += c.get_message_as_str()
+                    message += '<br>\n'
+                if c.warn > 0:
+                    message += 'WARN: '
+                    message += c.get_message_as_str()
+                    message += '<br>\n'
+                if c.notice > 0:
+                    message += 'NOTICE: '
+                    message += c.get_message_as_str()
+                    message += '<br>\n'
+
+
+        debug("Pager Message : ",message)              
+        
+        # send alert
+        r = teams_send(url=url, title=title, message=message ,color=color, origin=origin)
+        if r == 200:
+            logit("Alerts : alert sent to Teams ")
+        else:
+            logit("Alerts : couldn't send alert to Teams - response  " + str(r))
+
+        # update rate_limit
+        cmt.PERSIST.set_key("pager_last_send",t2)
+
+
+
+

--- a/checks/boottime.py
+++ b/checks/boottime.py
@@ -11,11 +11,12 @@ def check_boottime(c):
     days = int (boottime / 86400)
 
     m1 = CheckItem('boottime_seconds',boottime,"Seconds since last reboot", unit='seconds')
+    h_sec = m1.human()
     c.add_item(m1)
 
     m2 = CheckItem('boottime_days',days,'Days since last reboot', unit='days')
     c.add_item(m2)
 
     # TODO add human format (j/h/m/s)
-    c.add_message("Days since last reboot : {} days ({} sec.)".format(days,boottime))
+    c.add_message("days since last reboot : {} days - {} sec.".format(days,h_sec))
     return c

--- a/checks/boottime.py
+++ b/checks/boottime.py
@@ -17,6 +17,5 @@ def check_boottime(c):
     m2 = CheckItem('boottime_days',days,'Days since last reboot', unit='days')
     c.add_item(m2)
 
-    # TODO add human format (j/h/m/s)
     c.add_message("days since last reboot : {} days - {} sec.".format(days,h_sec))
     return c

--- a/checks/certificate.py
+++ b/checks/certificate.py
@@ -2,7 +2,9 @@ import sys
 import ssl
 import socket
 import datetime
-from cmt_shared import Check, CheckItem, parse_duration
+
+from cmt_shared import Check, CheckItem
+from helpers import parse_duration
 
 
 def check_certificate(c):

--- a/checks/certificate.py
+++ b/checks/certificate.py
@@ -1,0 +1,113 @@
+import sys
+import ssl
+import socket
+import datetime
+from cmt_shared import Check, CheckItem, parse_duration
+
+
+def check_certificate(c):
+
+    assert sys.version_info >= (3, 5), "Python interpreter is too old"
+
+    # get every settings at the start so that we don't crash mid-check if a key
+    # is missing
+    hostname = c.conf["hostname"]
+    threshold = parse_duration(c.conf["alert_expires_in"])
+    port = c.conf.get("port", 443)
+
+    c.add_item(CheckItem("certificate_hostname", hostname, "Hostname"))
+    c.add_item(CheckItem("certificate_port", port, "Port"))
+
+    cert_infos = get_certificate_infos(hostname, port)
+
+    # certificate dates are in utc. Just reading the warning from the documentation,
+    # it seems like Python's datetime modules is pretty bad when it comes to managing
+    # timezones correctly. So, keep everything in terms of UTC.
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    if now > cert_infos["notAfter"]:
+        c.alert += 1
+        c.add_message(
+            "hostname: {}:{} - certifcate expired by {}".format(
+                hostname, port, now - cert_infos["notAfter"]
+            )
+        )
+    elif now < cert_infos["notBefore"]:
+        c.alert += 1
+        c.add_message(
+            "hostname: {}:{} - certifcate not yet valid (will be valid in {})".format(
+                hostname, port, cert_infos["notBefore"] - now
+            )
+        )
+
+    expires_in = cert_infos["notAfter"] - now
+    if expires_in < threshold:
+        c.alert += 1
+        c.add_message(
+            "hostname: {}:{} - certificate will expire soon (in {})".format(
+                hostname, port, expires_in
+            )
+        )
+
+    c.add_item(
+        CheckItem(
+            "certificate_expires_in",
+            int(round(expires_in.total_seconds())),
+            unit="seconds",
+        )
+    )
+    c.add_item(
+        CheckItem("certificate_issuer_common_name", cert_infos["issuer"]["commonName"])
+    )
+    c.add_item(
+        CheckItem(
+            "certificate_issuer_organization_name",
+            cert_infos["issuer"]["organizationName"],
+        )
+    )
+    c.add_item(
+        CheckItem(
+            "certificate_subject_common_name", cert_infos["subject"]["commonName"]
+        )
+    )
+    c.add_item(
+        CheckItem(
+            "certificate_subject_organization_name",
+            cert_infos["subject"]["organizationName"],
+        )
+    )
+
+    return c
+
+
+def get_certificate_infos(hostname, port):
+    context = ssl.create_default_context()
+
+    with socket.create_connection((hostname, 443)) as sock:
+        with context.wrap_socket(sock, server_hostname=hostname) as ssock:
+            cert = ssock.getpeercert()
+
+    if cert is None:
+        raise ValueError(f"no certificate found ({cert})")
+
+    todatetime = lambda x: datetime.datetime.fromtimestamp(
+        ssl.cert_time_to_seconds(x), tz=datetime.timezone.utc
+    )
+    return {
+        "notAfter": todatetime(cert["notAfter"]),
+        "notBefore": todatetime(cert["notBefore"]),
+        "issuer": get_source_infos(cert["issuer"]),
+        "subject": get_source_infos(cert["subject"]),
+    }
+
+
+def get_source_infos(rdns):
+    infos = {}
+    for rdn in rdns:
+        for key, value in rdn:
+            if key in ("organizationName", "commonName"):
+                infos[key] = value
+
+    return {
+        "organizationName": infos.get("organizationName", "<no organization name>"),
+        "commonName": infos.get("commonName", "<no common name>"),
+    }

--- a/checks/certificate.py
+++ b/checks/certificate.py
@@ -15,6 +15,7 @@ def check_certificate(c):
     # get every settings at the start so that we don't crash mid-check if a key
     # is missing
     hostname = c.conf["hostname"]
+    # should there be a default value?
     threshold = parse_duration(c.conf["alert_expires_in"])
     port = c.conf.get("port", 443)
 

--- a/checks/certificate.py
+++ b/checks/certificate.py
@@ -6,7 +6,8 @@ from cmt_shared import Check, CheckItem, parse_duration
 
 
 def check_certificate(c):
-
+    # if this assertion fails, then we have to be even more careful of timezones.
+    # ref ssl.cert_time_to_seconds
     assert sys.version_info >= (3, 5), "Python interpreter is too old"
 
     # get every settings at the start so that we don't crash mid-check if a key
@@ -27,14 +28,14 @@ def check_certificate(c):
     if now > cert_infos["notAfter"]:
         c.alert += 1
         c.add_message(
-            "hostname: {}:{} - certifcate expired by {}".format(
+            "hostname: {}:{} - certificate expired by {}".format(
                 hostname, port, now - cert_infos["notAfter"]
             )
         )
     elif now < cert_infos["notBefore"]:
         c.alert += 1
         c.add_message(
-            "hostname: {}:{} - certifcate not yet valid (will be valid in {})".format(
+            "hostname: {}:{} - certificate not yet valid (will be valid in {})".format(
                 hostname, port, cert_infos["notBefore"] - now
             )
         )

--- a/checks/cpu.py
+++ b/checks/cpu.py
@@ -17,5 +17,5 @@ def check_cpu(c):
     i  = CheckItem('cpu',cpu,"CPU Percentage", unit='%')   
     c.add_item(i)
 
-    c.add_message("CPU = {} %".format(cpu))
+    c.add_message("usage : {} %".format(cpu))
     return c

--- a/checks/cpu.py
+++ b/checks/cpu.py
@@ -12,6 +12,8 @@ def check_cpu(c):
 
     cpu = psutil.cpu_percent(interval=2)
 
+    # c.persist['cpu'] = cpu
+
     i  = CheckItem('cpu',cpu,"CPU Percentage", unit='%')   
     c.add_item(i)
 

--- a/checks/disk.py
+++ b/checks/disk.py
@@ -17,18 +17,24 @@ def check_disk(c):
     c.add_item(ci)
 
     ci = CheckItem('disk_total',disk[0],"Total (Bytes)", unit='bytes')
+    h_total = ci.human()
+    c.add_item(ci)
+
+    ci = CheckItem('disk_used',disk[1],"Used (Bytes)", unit='bytes')
+    h_used = ci.human()
     c.add_item(ci)
 
     ci = CheckItem('disk_free',disk[2],"Free (Bytes)", unit='bytes')
+    h_free = ci.human()
     c.add_item(ci)
 
     ci = CheckItem('disk_percent',disk[3],"Used (percent)", unit='%')
     if disk[3] > alert_threshold:
         c.alert += 1
-        c.add_message("Disk {} - critical capacity ({} %)".format(path,disk[3]))
+        c.add_message("path : {} - critical capacity ({} %)".format(path,disk[3]))
 
     else:
-        c.add_message("Disk {} - bytes free {}/{}  -  used percent {} %".format(path, disk[2], disk[0], disk[3]))
+        c.add_message("path : {} - used: {} % - used: {} - free: {} - total: {} ".format(path, disk[3],h_used, h_free,h_total))
     
     c.add_item(ci)
 

--- a/checks/folder.py
+++ b/checks/folder.py
@@ -37,8 +37,6 @@ def check_folder(c):
 
     global s_dirs
 
-    #c = Check(module='folder') 
-
     path = c.conf['path']
 
     name = path
@@ -50,17 +48,13 @@ def check_folder(c):
     targets = []
     if 'target' in c.conf:
         targets = c.conf['target']
-        #print(targets)
 
     ci = CheckItem('folder_path',path)
     c.add_item(ci)
     ci = CheckItem('folder_name',name)
     c.add_item(ci)
 
-    if not os.path.exists(path):
-        ci = CheckItem('folder_status',"","ok/nok", unit="")
-        ci.value="nok"
-        c.add_item(ci)        
+    if not os.path.exists(path):      
         c.alert += 1
         c.add_message("{} missing".format(path))       
         return c
@@ -122,15 +116,12 @@ def check_folder(c):
 
     # Target checks
     # --------------
-    ci = CheckItem('folder_status',"","ok/nok", unit="")
     tgcount = 0
 
     # target : files_min: 4
     if 'files_min' in targets:
         tgcount += 1
         if s_count < targets['files_min']:
-            ci.value="nok"
-            c.add_item(ci)
             c.alert += 1
             c.add_message ("{} :  too few files ({})".format(path,s_count))
             return c
@@ -139,8 +130,6 @@ def check_folder(c):
     if 'files_max' in targets:
         tgcount += 1
         if s_count > targets['files_max']:
-            ci.value="nok"
-            c.add_item(ci)
             c.alert += 1
             c.add_message ("{} : too many files ({})".format(path,s_count))
             return c
@@ -149,8 +138,6 @@ def check_folder(c):
     if 'size_max' in targets:
         tgcount += 1
         if s_size > targets['size_max']:
-            ci.value="nok"
-            c.add_item(ci)
             c.alert += 1
             c.add_message("{} : too big ({})".format(path,s_size))
             return c            
@@ -159,8 +146,6 @@ def check_folder(c):
     if 'size_min' in targets:
         tgcount += 1
         if s_size < targets['size_min']:
-            ci.value="nok"
-            c.add_item(ci)
             c.alert += 1
             c.add_message("{} : too small ({})".format(path,s_size))
             return c            
@@ -170,8 +155,6 @@ def check_folder(c):
         tgcount += 1
         if s_minage != -1:
             if int(now - s_minage) > targets ['age_max']:
-                ci.value="nok"
-                c.add_item(ci)
                 c.alert += 1
                 c.add_message("{} : some files too old ({} sec)".format(path,int(now - s_minage)))
                 return c                
@@ -181,8 +164,6 @@ def check_folder(c):
         tgcount += 1
         if s_maxage != 0:
             if int(now - s_maxage) < targets ['age_min']:
-                ci.value="nok"
-                c.add_item(ci)
                 c.alert += 1
                 c.add_message("{} : some files too young ({} sec)".format(path,int(now - s_maxage)))
                 return c   
@@ -193,14 +174,9 @@ def check_folder(c):
         flist = targets['has_files']
         for f in flist:
             if f not in s_files:
-                ci.value="nok"
-                c.add_item(ci)
                 c.alert += 1
                 c.add_message("{} : expected file not found ({})".format(path,f))
                 return c
-
-    ci = CheckItem('folder_status',"ok","check if targets are met.", unit="ok/nok")
-    c.add_item(ci)
 
     c.add_message("{} ({}) ok - {} files, {} dirs, {} bytes - {} targets OK".format(name, path, s_count, s_dirs, s_size, tgcount))
     return c

--- a/checks/load.py
+++ b/checks/load.py
@@ -23,5 +23,5 @@ def check_load(c):
     l15.description='CPU Load Average, 15 minutes'
     c.add_item(l15)
     
-    c.add_message("Load : {} {} {}".format(load[0], load[1], load[2]))
+    c.add_message("1/5/15 min : {}  {}  {}".format(load[0], load[1], load[2]))
     return c

--- a/checks/memory.py
+++ b/checks/memory.py
@@ -18,11 +18,18 @@ def check_memory(c):
     c.add_item(m1)
 
     m2  = CheckItem('memory_used',memory.used,"Memory used (bytes)", unit='bytes')
+    h_used = m2.human()
     c.add_item(m2)
 
     m3  = CheckItem('memory_available',memory.available,"Memory available (bytes)", unit='bytes')
+    h_avail = m3.human()
     c.add_item(m3)
 
-    c.add_message("memory : used {} % - used {} bytes - avail {} bytes ".format(memory.percent, memory.used, memory.available) )
+    m4  = CheckItem('memory_total',memory.total,"Memory total (bytes)", unit='bytes')
+    h_total = m4.human()
+    c.add_item(m4)
+
+
+    c.add_message("used {} % - used {} - avail {} - total {}".format(memory.percent, h_used, h_avail, h_total) )
 
     return c

--- a/checks/mount.py
+++ b/checks/mount.py
@@ -40,12 +40,13 @@ def check_mount(c):
         if part.mountpoint == path:
             ci.value="ok"
             c.add_item(ci)
-            c.add_message("mount for {} found".format(path))
+            c.add_message("path {} found".format(path))
             return c
 
     ci.value = "nok"
     c.add_item(ci)
+    
     c.alert += 1
-    c.add_message("mount for {} not found".format(path))
+    c.add_message("path {} not found".format(path))
 
     return c

--- a/checks/mount.py
+++ b/checks/mount.py
@@ -6,13 +6,10 @@ from cmt_shared import Check, CheckItem
 
 def check_mount(c):
     
-    '''Checks mount points'''
-
-    # OUTPUT
-    # cmt_mount
-    # cmt_mount_status
-
-    #c = Check(module='mount') 
+    '''Checks mount points
+       OUTPUT
+         - cmt_mount
+    '''
 
     partitions=psutil.disk_partitions(all=False)
 
@@ -33,18 +30,11 @@ def check_mount(c):
 
     ci = CheckItem('mount',path)
     c.add_item(ci)
-
-    ci = CheckItem('mount_status',"","ok/nok", unit="")
     
     for part in partitions:
         if part.mountpoint == path:
-            ci.value="ok"
-            c.add_item(ci)
             c.add_message("path {} found".format(path))
             return c
-
-    ci.value = "nok"
-    c.add_item(ci)
     
     c.alert += 1
     c.add_message("path {} not found".format(path))

--- a/checks/ping.py
+++ b/checks/ping.py
@@ -37,12 +37,12 @@ def check_ping(c):
     if response == 0:
         ci.value = "ok"
         c.add_item(ci)
-        c.add_message("ping to {} ok".format(host))
+        c.add_message("{} ok".format(host))
 
     else:
         ci.value = "nok"
         c.add_item(ci)
         c.alert += 1
-        c.add_message("check_ping - {} not responding".format(host))
+        c.add_message("{} not responding".format(host))
 
     return c

--- a/checks/ping.py
+++ b/checks/ping.py
@@ -8,23 +8,18 @@ from cmt_shared import Check, CheckItem
 
 def check_ping(c):
 
-    '''Ping a remote host and return availability'''
+    '''Ping a remote host and return availability
+       Output:
+          - cmt_ping
+    '''
 
-    # cmt_ping
-    # cmt_ping_status
-
-    #c = Check(module='ping') 
     host = c.conf['host']
 
     ci = CheckItem('ping',host)
     c.add_item(ci)
 
-    ci = CheckItem('ping_status',"","ok/nok", unit="")
 
-    # TODO : switch to subprocess
     #response = os.system("ping -c 1 -W 2 " + host + "> /dev/null 2>&1")
-
-
     proc = subprocess.Popen(
         ["ping", "-c", "1", "-W" "2", host],
         stdout=subprocess.DEVNULL,
@@ -35,13 +30,8 @@ def check_ping(c):
 
 
     if response == 0:
-        ci.value = "ok"
-        c.add_item(ci)
         c.add_message("{} ok".format(host))
-
     else:
-        ci.value = "nok"
-        c.add_item(ci)
         c.alert += 1
         c.add_message("{} not responding".format(host))
 

--- a/checks/process.py
+++ b/checks/process.py
@@ -54,21 +54,24 @@ def check_process(c):
             ci.value="ok"
             c.add_item(ci)
 
-            ci = CheckItem('process_memory',proc.memory_info().rss,"rss", unit="bytes")
+            mem = proc.memory_info().rss
+            ci = CheckItem('process_memory',mem,"rss", unit="bytes")
+            h_mem = ci.human()
             c.add_item(ci)
             #print (proc.memory_info().rss)
             
-            ci = CheckItem('process_cpu',proc.cpu_times().user,"cpu time, user", unit='seconds')
+            cpu = proc.cpu_times().user
+            ci = CheckItem('process_cpu',cpu,"cpu time, user", unit='seconds')
             c.add_item(ci)
 
-            c.add_message("process {} found ({})".format(name, psname))
+            c.add_message("{} found ({}) - memory rss {} - cpu {} sec.".format(name, psname, h_mem, cpu ))
             return c
 
     ci.value = "nok"
     c.add_item(ci)
 
     c.alert += 1
-    c.add_message("process {} missing ({})".format(name, psname))
+    c.add_message("{} missing ({})".format(name, psname))
 
     return c
 

--- a/checks/process.py
+++ b/checks/process.py
@@ -36,7 +36,6 @@ def check_process(c):
     ci = CheckItem('process_name',name,"")
     c.add_item(ci)
 
-    ci = CheckItem('process_status',"","ok/nok", unit="")
     
     for proc in psutil.process_iter():
 
@@ -51,14 +50,11 @@ def check_process(c):
         # pinfo = proc.as_dict(attrs=['name','pid','memory_info','cpu_times'])
         if processName  == psname:
 
-            ci.value="ok"
-            c.add_item(ci)
 
             mem = proc.memory_info().rss
             ci = CheckItem('process_memory',mem,"rss", unit="bytes")
             h_mem = ci.human()
             c.add_item(ci)
-            #print (proc.memory_info().rss)
             
             cpu = proc.cpu_times().user
             ci = CheckItem('process_cpu',cpu,"cpu time, user", unit='seconds')
@@ -66,9 +62,6 @@ def check_process(c):
 
             c.add_message("{} found ({}) - memory rss {} - cpu {} sec.".format(name, psname, h_mem, cpu ))
             return c
-
-    ci.value = "nok"
-    c.add_item(ci)
 
     c.alert += 1
     c.add_message("{} missing ({})".format(name, psname))

--- a/checks/swap.py
+++ b/checks/swap.py
@@ -12,7 +12,13 @@ def check_swap(c):
     c.add_item(m1)
 
     m2 = CheckItem('swap_used',swap.used,'Swap used (bytes)', unit = 'bytes')
+    h_used = m2.human()
     c.add_item(m2)
 
-    c.add_message("swap used : {} % ".format(swap.percent))
+    m3 = CheckItem('swap_total',swap.total,'Swap total (bytes)', unit = 'bytes')
+    h_total = m3.human()
+    c.add_item(m3)
+
+
+    c.add_message("used: {} % /  {} - total {}".format(swap.percent, h_used, h_total))
     return c

--- a/checks/url.py
+++ b/checks/url.py
@@ -72,6 +72,6 @@ def check_url(c):
     ci = CheckItem('url_status','ok','')
     c.add_item(ci) 
 
-    c.add_message("{} - {} - http={} - {}ms ; pattern OK".format(name, url, resp.status_code, elapsed_time))
+    c.add_message("{} - {} - http={} - {} ms ; pattern OK".format(name, url, resp.status_code, elapsed_time))
     return c
 

--- a/checks/url.py
+++ b/checks/url.py
@@ -23,6 +23,7 @@ def check_url(c):
     pattern      = c.conf.get('pattern',"")
     my_redirects = c.conf.get("allow_redirects",False) == True
     my_sslverify = c.conf.get("ssl_verify",False) == True
+    my_host      = c.conf.get("host","")
 
     ci = CheckItem('url_name',name,'')
     c.add_item(ci)
@@ -33,11 +34,15 @@ def check_url(c):
 
     start_time = time.time()
 
+    headers = {}
+    if my_host != "":
+        headers['Host'] = my_host
+
     try:
-        resp = requests.get(url, timeout=5, verify=my_sslverify, allow_redirects = my_redirects)
+        resp = requests.get(url, headers = headers, timeout=5, verify=my_sslverify, allow_redirects = my_redirects)
     except:
         c.alert += 1
-        c.add_message("{} - {} - no response to query".format(name,url))
+        c.add_message("{} - {} [Host: {}] - no response to query".format(name,url, my_host))
         return c
 
     elapsed_time = int ( 1000 * (time.time() - start_time) )
@@ -46,16 +51,16 @@ def check_url(c):
 
     if resp.status_code != 200:
         c.alert += 1
-        c.add_message("{} - {} - bad http code response ({})".format(name,url, resp.status_code))
+        c.add_message("{} - {} [Host: {}]- bad http code response ({})".format(name,url, my_host, resp.status_code))
         return c
 
     # check pattern
     mysearch = re.search(pattern,resp.text)
     if not mysearch:
         c.alert += 1
-        c.add_message("expected pattern not found for {} ({})".format(name, url))
+        c.add_message("expected pattern not found for {} ({} [Host: {}])".format(name, url, my_sslverify))
         return c
 
-    c.add_message("{} - {} - http={} - {} ms ; pattern OK".format(name, url, resp.status_code, elapsed_time))
+    c.add_message("{} - {} [Host: {}] - http={} - {} ms ; pattern OK".format(name, url, my_host, resp.status_code, elapsed_time))
     return c
 

--- a/checks/url.py
+++ b/checks/url.py
@@ -17,17 +17,13 @@ def check_url(c):
     # cmt_url
     # cmt_url_name
     # cmt_url_msec
-    # cmt_url_status
-
-    #c = Check(module='url') 
 
     name         = c.name
     url          = c.conf['url']
-    pattern      = c.conf['pattern']
+    pattern      = c.conf.get('pattern',"")
     my_redirects = c.conf.get("allow_redirects",False) == True
     my_sslverify = c.conf.get("ssl_verify",False) == True
 
-    
     ci = CheckItem('url_name',name,'')
     c.add_item(ci)
 
@@ -40,9 +36,6 @@ def check_url(c):
     try:
         resp = requests.get(url, timeout=5, verify=my_sslverify, allow_redirects = my_redirects)
     except:
-        ci = CheckItem('url_status','nok','')
-        ci.description = 'no response to query'
-        c.add_item(ci)
         c.alert += 1
         c.add_message("{} - {} - no response to query".format(name,url))
         return c
@@ -52,9 +45,6 @@ def check_url(c):
     c.add_item(ci) 
 
     if resp.status_code != 200:
-        ci = CheckItem('url_status','nok','')
-        ci.description = 'bad response code : ' + str(resp.status_code)
-        c.add_item(ci) 
         c.alert += 1
         c.add_message("{} - {} - bad http code response ({})".format(name,url, resp.status_code))
         return c
@@ -62,15 +52,9 @@ def check_url(c):
     # check pattern
     mysearch = re.search(pattern,resp.text)
     if not mysearch:
-        ci = CheckItem('url_status','nok','')
-        c.add_item(ci) 
-        ci.description = 'expected pattern not found'
         c.alert += 1
         c.add_message("expected pattern not found for {} ({})".format(name, url))
         return c
-
-    ci = CheckItem('url_status','ok','')
-    c.add_item(ci) 
 
     c.add_message("{} - {} - http={} - {} ms ; pattern OK".format(name, url, resp.status_code, elapsed_time))
     return c

--- a/cmt.py
+++ b/cmt.py
@@ -88,7 +88,6 @@ if __name__=="__main__":
         pager_test()
         sys.exit()
 
-    # TODO : list modules
     if cmt.ARGS["listmodules"]:
         display_modules()
         sys.exit()
@@ -165,8 +164,6 @@ if __name__=="__main__":
         # ---------------
         check_result = cmt.GLOBAL_MODULE_MAP[modulename]['check'](check_result)
 
-
-        # TODO done / no output ; available results only
         if cmt.ARGS["available"]:
             break
 

--- a/cmt.py
+++ b/cmt.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python3
-# cavaliba.com - 2020 - CMT_monitor - cmt.py 
-
+# cavaliba.com - 2020 - CMT_monitor - cmt.py
 
 import os
 import sys
@@ -14,8 +13,6 @@ import requests
 
 # global variables
 import cmt_globals as cmt
-
-
 
 # shared functions and class
 from cmt_shared import logit, debug, abort, bcolors
@@ -45,8 +42,8 @@ def signal_handler(signum, frame):
 if __name__=="__main__":
 
 
-    
-    cmt.ARGS = parse_arguments()    
+
+    cmt.ARGS = parse_arguments()
 
     if cmt.ARGS["version"]:
         display_version()
@@ -141,7 +138,7 @@ if __name__=="__main__":
         # no info
         if ts_check == "n/a":
             # module level ?
-            if not is_module_active_in_conf(modulename):  
+            if not is_module_active_in_conf(modulename):
                 debug("  module disabled in conf")
                 continue #no
         elif not is_timeswitch_on(ts_check):
@@ -184,16 +181,16 @@ if __name__=="__main__":
         # keep returned Persist structure in check_result
         cmt.PERSIST.set_key(check_result.get_id(), check_result.persist)
 
-        
+
         if cmt.ARGS['short']:
             check_result.print_to_cli_short()
         else:
             check_result.print_to_cli_detail()
-        
-        if cmt.ARGS["report"]:            
+
+        if cmt.ARGS["report"]:
             check_result.send_metrology()
 
-        
+
         # add Check to report
         report.add_check(check_result)
 

--- a/cmt_elastic_template.json
+++ b/cmt_elastic_template.json
@@ -24,7 +24,13 @@
         "cmt_memory_used" : {
           "type" : "long"
         },
+        "cmt_memory_total" : {
+          "type" : "long"
+        },
         "cmt_swap_used" : {
+          "type" : "long"
+        },
+        "cmt_swap_total" : {
           "type" : "long"
         },
         "cmt_swap_percent" : {

--- a/cmt_globals.py
+++ b/cmt_globals.py
@@ -1,4 +1,4 @@
-# cavaliba.com - 2020 - CMT_monitor - cmt.py 
+# cavaliba.com - 2020 - CMT_monitor - cmt.py
 
 # cmt_globals
 
@@ -18,6 +18,7 @@ from checks.url import check_url
 from checks.process import check_process
 from checks.ping import check_ping
 from checks.folder import check_folder
+from checks.certificate import check_certificate
 
 
 requests.packages.urllib3.disable_warnings()
@@ -40,7 +41,7 @@ elif __file__:
 
 #RATE_LIMIT_FILE = os.path.join(HOME_DIR, "alert.last")
 
-GRAYLOG_HTTP_TIMEOUT = 5 
+GRAYLOG_HTTP_TIMEOUT = 5
 
 # http access to remote url for additional config
 REMOTE_CONFIG_TIMEOUT = 3
@@ -57,7 +58,7 @@ DEFAULT_HYSTERESIS_NORMAL_DELAY = 120
 # persist
 DEFAULT_PERSIST_FILE = os.path.join(HOME_DIR, "persist.json")
 
-# Used to load / merge config 
+# Used to load / merge config
 DEFAULT_CONF_TOP_ENTRIES = ['global','modules','checks','metrology_servers', 'pagers']
 
 # =====================================================================
@@ -65,17 +66,18 @@ DEFAULT_CONF_TOP_ENTRIES = ['global','modules','checks','metrology_servers', 'pa
 # =====================================================================
 
 GLOBAL_MODULE_MAP = {
-    "load"     : {"check": check_load     },
-    "cpu"      : {"check": check_cpu      },
-    "memory"   : {"check": check_memory   },
-    "swap"     : {"check": check_swap     },
-    "boottime" : {"check": check_boottime },
-    "mount"    : {"check": check_mount    },
-    "disk"     : {"check": check_disk     },
-    "url"      : {"check": check_url      },
-    "process"  : {"check": check_process  },
-    "ping"     : {"check": check_ping     },
-    "folder"   : {"check": check_folder   },
+    "load"       : {"check": check_load        },
+    "cpu"        : {"check": check_cpu         },
+    "memory"     : {"check": check_memory      },
+    "swap"       : {"check": check_swap        },
+    "boottime"   : {"check": check_boottime    },
+    "mount"      : {"check": check_mount       },
+    "disk"       : {"check": check_disk        },
+    "url"        : {"check": check_url         },
+    "process"    : {"check": check_process     },
+    "ping"       : {"check": check_ping        },
+    "folder"     : {"check": check_folder      },
+    "certificate": {"check": check_certificate }
 }
 
 

--- a/cmt_globals.py
+++ b/cmt_globals.py
@@ -24,7 +24,7 @@ requests.packages.urllib3.disable_warnings()
 SESSION = requests.session()
 
 # -----------------
-VERSION = "CMT - Version 1.0.0.RC - (c) Cavaliba.com - 2020/11/24"
+VERSION = "CMT - Version 1.0.0 - (c) Cavaliba.com - 2020/11/29"
 
 MAX_EXECUTION_TIME = 50
 
@@ -57,6 +57,8 @@ DEFAULT_HYSTERESIS_NORMAL_DELAY = 120
 # persist
 DEFAULT_PERSIST_FILE = os.path.join(HOME_DIR, "persist.json")
 
+# Used to load / merge config 
+DEFAULT_CONF_TOP_ENTRIES = ['global','modules','checks','metrology_servers', 'pagers']
 
 # =====================================================================
 # Checks list & MAPs : map Check names to python functions

--- a/cmt_globals.py
+++ b/cmt_globals.py
@@ -33,7 +33,7 @@ MAX_EXECUTION_TIME = 50
 # determine if application is a script file or frozen exe from PyInstaller
 if getattr(sys, 'frozen', False):
     HOME_DIR = os.path.dirname(sys.executable)
-    HOME_DIR = "/opt/cmt_monitor"
+    HOME_DIR = "/opt/cmt"
 elif __file__:
     HOME_DIR = os.path.dirname(__file__)
 

--- a/cmt_globals.py
+++ b/cmt_globals.py
@@ -48,6 +48,11 @@ REMOTE_CONFIG_TIMEOUT = 3
 # post to Teams
 TEAMS_TIMEOUT = 5
 
+# Hystereis
+# delay before going to alerting state
+DEFAULT_HYSTERESIS_ALERT_DELAY = 120
+# delay before resuming to normal state
+DEFAULT_HYSTERESIS_NORMAL_DELAY = 120
 
 # persist
 DEFAULT_PERSIST_FILE = os.path.join(HOME_DIR, "persist.json")

--- a/cmt_shared.py
+++ b/cmt_shared.py
@@ -1,4 +1,4 @@
-# cavaliba.com - 2020 - CMT_monitor - cmt.py 
+# cavaliba.com - 2020 - CMT_monitor - cmt.py
 # cmt_shared.py
 #    - common functions, class and structures
 
@@ -16,7 +16,7 @@ import requests
 requests.packages.urllib3.disable_warnings()
 
 import cmt_globals as cmt
-from cmt_globals import *
+# from cmt_globals import *
 
 
 # ----------------------------------------------------------
@@ -75,10 +75,10 @@ def is_timeswitch_on(myconfig):
 
     if myconfig == "False" or myconfig =="no"  or myconfig == "false":
         return False
-    
+
     myarray = myconfig.split()
     action = myarray.pop(0)
-    
+
     if action  == "after":
         mynow = datetime.datetime.today().strftime("%Y-%m-%d %H:%M:%S")
         target = ' '.join(myarray)
@@ -120,6 +120,7 @@ def is_timeswitch_on(myconfig):
     # default, unknown / no match
     return False
 
+
 # -----------------------------------------------------
 # short commands
 # -----------------------------------------------------
@@ -134,7 +135,7 @@ def display_modules():
 
     for key in cmt.GLOBAL_MODULE_MAP:
         print("  - ", key )
-    
+
 
 # ----------------------------------------------------------
 # Args on CLI
@@ -144,45 +145,45 @@ def parse_arguments():
     parser = argparse.ArgumentParser(description='CMT - Cavaliba Monitoring')
 
     #parser.add_argument('--conf', dest="config_file", type=str ,help="configuration file")
-    
-    parser.add_argument('--report', help='send events to Metrology servers', 
+
+    parser.add_argument('--report', help='send events to Metrology servers',
         action='store_true', required=False)
-    parser.add_argument('--pager', help='send alerts to Pagers', 
+    parser.add_argument('--pager', help='send alerts to Pagers',
         action='store_true', required=False)
     parser.add_argument('--persist', help='persist data accross CMT runs (use in cron)',
         action='store_true', required=False)
 
-    parser.add_argument('--conf', help='specify alternate yaml config file', 
+    parser.add_argument('--conf', help='specify alternate yaml config file',
         action='store', required=False)
 
-    parser.add_argument('modules', nargs='*',  
+    parser.add_argument('modules', nargs='*',
         action='append', help='modules to check')
-    
-    parser.add_argument('--pagertest', help='send test message to teams and exit', 
+
+    parser.add_argument('--pagertest', help='send test message to teams and exit',
         action='store_true', required=False)
-    parser.add_argument('--no-pager-rate-limit', help='disable pager rate limit', 
-        action='store_true', required=False)  
+    parser.add_argument('--no-pager-rate-limit', help='disable pager rate limit',
+        action='store_true', required=False)
 
 
-    parser.add_argument('--checkconfig', help='checkconfig and exit', 
+    parser.add_argument('--checkconfig', help='checkconfig and exit',
         action='store_true', required=False)
 
-    parser.add_argument('--version', '-v', help='display current version', 
+    parser.add_argument('--version', '-v', help='display current version',
         action='store_true', required=False)
-    parser.add_argument('--debug', help='verbose/debug output', 
+    parser.add_argument('--debug', help='verbose/debug output',
         action='store_true', required=False)
-    parser.add_argument('--debug2', help='more debug', 
+    parser.add_argument('--debug2', help='more debug',
         action='store_true', required=False)
 
-    parser.add_argument('--short','-s', help='short compact cli output', 
+    parser.add_argument('--short','-s', help='short compact cli output',
         action='store_true', required=False)
-    parser.add_argument('--devmode', help='dev mode, no pager, no remote metrology', 
-        action='store_true', required=False)    
+    parser.add_argument('--devmode', help='dev mode, no pager, no remote metrology',
+        action='store_true', required=False)
 
 
-    parser.add_argument('--listmodules', help='display available modules', 
+    parser.add_argument('--listmodules', help='display available modules',
         action='store_true', required=False)
-    parser.add_argument('--available', help='display available entries found for modules (manual run on target)', 
+    parser.add_argument('--available', help='display available entries found for modules (manual run on target)',
         action='store_true', required=False)
 
 
@@ -200,7 +201,7 @@ def load_conf():
     conf = conf_add_default_modules(conf)
     conf = load_conf_dirs(conf)
     conf = load_conf_remote(conf)
-    
+
     return conf
 
 
@@ -209,11 +210,11 @@ def load_conf_master():
 
     debug("Load master conf")
 
-    if cmt.ARGS['conf']: 
-        config_file = cmt.ARGS['conf']    
-    else:        
-        config_file = os.path.join(cmt.HOME_DIR, "conf.yml")    
-    
+    if cmt.ARGS['conf']:
+        config_file = cmt.ARGS['conf']
+    else:
+        config_file = os.path.join(cmt.HOME_DIR, "conf.yml")
+
     debug("Config file : ", config_file)
 
     if not os.path.exists(config_file):
@@ -260,14 +261,14 @@ def load_conf_dirs(conf):
 def load_conf_remote(conf):
 
     debug("Load remote conf")
-    
+
     # load remote config from conf_url parameter
     if 'conf_url' in conf['global']:
-                
+
         url = conf['global']['conf_url']
         gro = conf['global'].get("cmt_group","nogroup")
         nod = conf['global'].get("cmt_node","nonode")
-    
+
         if url[-1] == '/':
             url = url + "{}_{}.txt".format(gro,nod)
 
@@ -292,7 +293,7 @@ def conf_add_default_modules(conf):
     for key in cmt.GLOBAL_MODULE_MAP:
         #print("  - ", key )
         if key not in conf['modules']:
-            conf['modules'][key] = {}            
+            conf['modules'][key] = {}
     return conf
 
 # -----------
@@ -309,13 +310,13 @@ def conf_add_top_entries(conf):
 # -----------
 # load a single file
 def conf_load_file(config_file):
-    
+
     with open(config_file) as f:
         conf = yaml.load(f, Loader=yaml.SafeLoader)
         #print(CONF)
         #print(json.dumps(CONF, indent=2))
 
-    # # verify content  
+    # # verify content
     if conf is None:
         return {}
     #    abort("Bad config; Exiting.")
@@ -372,16 +373,16 @@ def is_module_active_in_conf(module):
         return True
 
     timerange = cmt.CONF['modules'][module].get("enable", "yes")
-    
+
     if is_timeswitch_on(timerange):
         return True
-    
+
     debug("module not enabled in conf : ", module)
     return False
 
 
 def conf_get_hysteresis(check):
-    ''' return configuration for alert_delay, resume_delay 
+    ''' return configuration for alert_delay, resume_delay
         with inheritance: check, module, global, DEFAULT.
     '''
 
@@ -455,7 +456,7 @@ def pager_test():
 
 
 # ------------------------------------------------------------
-# Metrology Servers 
+# Metrology Servers
 # ------------------------------------------------------------
 
 
@@ -465,7 +466,7 @@ def pager_test():
 def build_gelf_message(check):
     '''Prepare a GELF JSON message suitable to be sent to a Graylog GELF server.'''
 
-    graylog_data = '"version":"1.1",' 
+    graylog_data = '"version":"1.1",'
     graylog_data += '"host":"{}_{}",'.format(check.group, check.node)
 
     # common values
@@ -515,13 +516,13 @@ def build_gelf_message(check):
 
 
     graylog_data = '{' + graylog_data + '}'
-    
+
     return graylog_data
 
 
 
 def graylog_send_http_gelf(url, data=""):
-    
+
     headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
 
     if cmt.GRAYLOG_HTTP_SUSPENDED:
@@ -533,7 +534,7 @@ def graylog_send_http_gelf(url, data=""):
         return
 
     try:
-        r = cmt.SESSION.post(url, data=data, headers=headers, timeout = cmt.GRAYLOG_HTTP_TIMEOUT)    
+        r = cmt.SESSION.post(url, data=data, headers=headers, timeout = cmt.GRAYLOG_HTTP_TIMEOUT)
         debug("Message sent to graylog(http/gelf) ; status = " + str(r.status_code))
     except:
         logit("Error - couldn't send graylog message (http/gelf) to " + str(url))
@@ -543,7 +544,7 @@ def graylog_send_http_gelf(url, data=""):
 def graylog_send_udp_gelf(host, port=12201, data=""):
 
     #data = '"demo":"42"'
-    #mess = '{ "version":"1.1", "host":"host-test", "short_message":"CMT gelf test", ' + data + ' }'  
+    #mess = '{ "version":"1.1", "host":"host-test", "short_message":"CMT gelf test", ' + data + ' }'
 
 
     if cmt.ARGS['devmode']:
@@ -569,7 +570,7 @@ def graylog_send_udp_gelf(host, port=12201, data=""):
 class Persist():
     ''' Implement a persistent on-disk key/value structure, between cmt runs'''
 
-    def __init__(self, file = None):    
+    def __init__(self, file = None):
         self.file = file
         self.dict = {}
         self.load()
@@ -594,7 +595,7 @@ class Persist():
         data = ""
         try:
             with open(self.file,"r") as fi:
-                data=fi.read()            
+                data=fi.read()
         except:
             debug("ERROR - Persist() : couldn't read file {}".format(self.file))
         # decoding the JSON to dictionay
@@ -607,7 +608,7 @@ class Persist():
     def save(self):
 
         if not cmt.ARGS['persist']:
-            debug("Persist.save : disable (cli / no arg)")            
+            debug("Persist.save : disable (cli / no arg)")
             return
 
         debug("Persist.write() : ", self.file)
@@ -619,7 +620,7 @@ class Persist():
             debug("ERROR - Persist() : couldn't write file {}".format(self.file))
 
 
-    
+
 
 # ----------------------------------------------------------
 # Class CheckItem
@@ -657,7 +658,7 @@ class CheckItem():
         else:
             return ''
 
-    
+
 # ----------------------------------------------------------
 # Class Check
 # ----------------------------------------------------------
@@ -686,19 +687,19 @@ class Check():
         self.alert = 0
         self.warn = 0
         self.notice = 0
-        self.checkitems=[]    
+        self.checkitems=[]
 
         # set by framework after Check is performed, if pager_enable and alert>0
         self.pager = False
 
         # fields from conf
         self.conf = conf
-        
-        
+
+
         # persist values from previous run for same get_id()
         id = self.get_id()
         self.persist = cmt.PERSIST.get_key(id,{})
-        
+
         # compute alert_max_level
         self.alert_max_level = "alert"   # DEFAULT
         # check level ?
@@ -725,7 +726,7 @@ class Check():
 
     def add_item(self, item):
         ''' add a CheckItem instance to the Check items list '''
-        self.checkitems.append(item)          
+        self.checkitems.append(item)
 
     def get_id(self):
         ''' Returns unique check id '''
@@ -737,7 +738,7 @@ class Check():
         for mm in self.message:
             if len(v) > 0:
                 v = v + " ; "
-            v = v + mm 
+            v = v + mm
         return v
 
 
@@ -750,13 +751,13 @@ class Check():
 
         if level == "alert":
             return
-        
+
         if level == "warn":
             self.notice = self.warn
             self.warn = self.alert
             self.alert = 0
             return
-        
+
         if level == "notice":
             self.notice = self.alert
             self.alert = 0
@@ -773,21 +774,21 @@ class Check():
         # seconds for state transition normal to alert (if alert)
         alert_delay = conf_get_hysteresis(self)
 
-        hystpersist = cmt.PERSIST.get_key("hysteresis", {})        
+        hystpersist = cmt.PERSIST.get_key("hysteresis", {})
         id = self.get_id()
         hystpersist_item = hystpersist.get(id,{})
 
         hystlastrun = hystpersist_item.get('lastrun',0)
         now = int(time.time())
         delta = int ( now - hystlastrun )
-        
+
         duration_alert = hystpersist_item.get('duration_alert',0)
         oldstate = hystpersist_item.get('state','normal')
-        
+
         newstate = oldstate
 
         #print("Hysteresis", duration_alert, delta, alert_delay)
-        
+
         if self.alert > 0 :
             if oldstate == "normal":
                 duration_alert += delta
@@ -804,8 +805,8 @@ class Check():
             # adjust to warn ; not a transition
             self.adjust_alert_max_level("warn")
 
-        # write to Persist   
-        # lastrun   
+        # write to Persist
+        # lastrun
         # BUG
         hystpersist_item['lastrun'] = now
         hystpersist_item['duration_alert'] = duration_alert
@@ -830,18 +831,18 @@ class Check():
         print("{:12} {:10} {}".format(head, self.module, self.get_message_as_str()))
 
     def print_to_cli_detail(self):
-       
-        print()
-        print(bcolors.OKBLUE + bcolors.BOLD + "Check", self.module, bcolors.ENDC)        
 
-        for i in self.checkitems:    
+        print()
+        print(bcolors.OKBLUE + bcolors.BOLD + "Check", self.module, bcolors.ENDC)
+
+        for i in self.checkitems:
 
             v = str (i.value) + ' ' + str(i.unit) + ' (' + i.human() + ') '
             if len (i.description) > 0:
                 v = v + ' - ' + i.description
 
             print("cmt_{:18} {}".format(i.name, v))
-        
+
 
         head = bcolors.OKGREEN     + "OK     " + bcolors.ENDC
 
@@ -852,17 +853,17 @@ class Check():
         elif self.notice > 0:
             head = bcolors.OKBLUE  + "NOTICE " + bcolors.ENDC
 
-        print("{:31} {}".format(head, self.get_message_as_str()))        
+        print("{:31} {}".format(head, self.get_message_as_str()))
 
 
     def send_metrology(self):
-        
-        ''' Send Check results (event, multiple CheckItems) 
+
+        ''' Send Check results (event, multiple CheckItems)
             to metrology servers.
         '''
 
-        graylog_data = build_gelf_message(self)  
-        
+        graylog_data = build_gelf_message(self)
+
         for metro in cmt.CONF['metrology_servers']:
 
 
@@ -893,7 +894,7 @@ class Check():
 # ----------------------------------------------------------
 
 class Report():
-    
+
     '''A Report stores all the Checks from a single run of CMT.
        Pager alerts are sent to Pager targets at the end of the run.
     '''
@@ -968,7 +969,7 @@ class Report():
             debug("Pager  : disabled/inactive in global config.")
             return
 
-        # Find 'Alert' Pager         
+        # Find 'Alert' Pager
         if not 'alert' in cmt.CONF['pagers']:
             debug("No alert pager configured.")
             return
@@ -999,7 +1000,7 @@ class Report():
         origin = cmt.CONF['global']['cmt_group'] + '/' + cmt.CONF['global']['cmt_node']
         color = "FF0000"
         title = "ALERT from " + origin
-        
+
         message = ""
         for c in self.checks:
                 if c.alert > 0:
@@ -1016,8 +1017,8 @@ class Report():
                     message += '<br>\n'
 
 
-        debug("Pager Message : ",message)              
-        
+        debug("Pager Message : ",message)
+
         # send alert
         r = teams_send(url=url, title=title, message=message ,color=color, origin=origin)
         if r == 200:

--- a/cmt_shared.py
+++ b/cmt_shared.py
@@ -497,14 +497,14 @@ def build_gelf_message(check):
         has_alert = "yes"
     else:
         has_alert= "no"
-    graylog_data += '"cmt_alert":"{}"'.format(has_alert)
+    graylog_data += '"cmt_alert":"{}",'.format(has_alert)
 
     # cmt_warn ?
     if check.warn > 0:
         has_warn = "yes"
     else:
         has_warn= "no"
-    graylog_data += '"cmt_warning":"{}"'.format(has_warn)
+    graylog_data += '"cmt_warning":"{}",'.format(has_warn)
 
     # cmt_notice ?
     if check.notice > 0:

--- a/cmt_shared.py
+++ b/cmt_shared.py
@@ -192,6 +192,18 @@ def parse_arguments():
 # ------------------------------------------------------------
 # Configuration management
 # ------------------------------------------------------------
+def load_conf():
+
+    debug("Load conf")
+
+    conf = load_conf_master()
+    conf = conf_add_default_modules(conf)
+    conf = load_conf_dirs(conf)
+    conf = load_conf_remote(conf)
+    
+    return conf
+
+
 
 def load_conf_master():
 
@@ -274,15 +286,13 @@ def load_conf_remote(conf):
 
     return conf
 
+# -----------
+def conf_add_default_modules(conf):
 
-def load_conf():
-
-    debug("Load conf")
-
-    conf = load_conf_master()
-    conf = load_conf_dirs(conf)
-    conf = load_conf_remote(conf)
-    
+    for key in cmt.GLOBAL_MODULE_MAP:
+        #print("  - ", key )
+        if key not in conf['modules']:
+            conf['modules'][key] = {}            
     return conf
 
 # -----------
@@ -358,7 +368,8 @@ def is_module_active_in_conf(module):
 
     if not module in cmt.CONF['modules']:
         debug("module not in conf :", module)
-        return False
+        # DEFAULT : True
+        return True
 
     timerange = cmt.CONF['modules'][module].get("enable", "yes")
     

--- a/cmt_shared.py
+++ b/cmt_shared.py
@@ -197,8 +197,6 @@ def load_conf_master():
 
     debug("Load master conf")
 
-    # TODO : accept config as a parameter, check default locations
-
     if cmt.ARGS['conf']: 
         config_file = cmt.ARGS['conf']    
     else:        
@@ -291,8 +289,7 @@ def load_conf():
 def conf_add_top_entries(conf):
 
     # add missing top entries
-    # TODO : move list to DEFAULTs
-    for item in ['global','modules','checks','metrology_servers', 'pagers']:
+    for item in cmt.DEFAULT_CONF_TOP_ENTRIES:
         if not item in conf:
             debug("No {} entry in config ; added automatically.".format(item))
             conf[item] = {}
@@ -339,7 +336,7 @@ def conf_load_http(url):
 def conf_merge(conf1, conf2):
 
     debug("merge conf ")
-    for topitem in ['global','modules','checks','metrology_servers', 'pagers']:
+    for topitem in cmt.DEFAULT_CONF_TOP_ENTRIES:
         #print("  topitem = ", topitem,  "conf2 = " , conf2[topitem], type)
         #print (type(conf2[topitem]))
         for k in conf2[topitem]:

--- a/cmt_shared.py
+++ b/cmt_shared.py
@@ -489,8 +489,22 @@ def build_gelf_message(check):
         has_alert = "yes"
     else:
         has_alert= "no"
-    
     graylog_data += '"cmt_alert":"{}"'.format(has_alert)
+
+    # cmt_warn ?
+    if check.warn > 0:
+        has_warn = "yes"
+    else:
+        has_warn= "no"
+    graylog_data += '"cmt_warning":"{}"'.format(has_warn)
+
+    # cmt_notice ?
+    if check.notice > 0:
+        has_notice = "yes"
+    else:
+        has_notice= "no"
+    graylog_data += '"cmt_notice":"{}"'.format(has_notice)
+
 
     graylog_data = '{' + graylog_data + '}'
     

--- a/conf-mini.yml
+++ b/conf-mini.yml
@@ -1,0 +1,17 @@
+---
+
+# minimal CMT 1.0 configuration
+# for CLI usage
+
+global:
+  cmt_group: minidev
+  cmt_node: minihost
+  enable: yes
+
+#modules:
+#  load:
+#    enable: yes
+
+checks:
+  my_load:
+    module: load

--- a/conf-mini.yml.ori
+++ b/conf-mini.yml.ori
@@ -1,0 +1,17 @@
+---
+
+# minimal CMT 1.0 configuration
+# for CLI usage
+
+global:
+  cmt_group: minidev
+  cmt_node: minihost
+  enable: yes
+
+#modules:
+#  load:
+#    enable: yes
+
+checks:
+  my_load:
+    module: load

--- a/conf.yml.ori
+++ b/conf.yml.ori
@@ -1,28 +1,45 @@
 ---
 # Cavaliba / cmt_monitor / conf.yml
-# V1.0.beta
+# V 1.0.0
 
-# Global
-# ------
+# this is the main config file
+
+# Global Section
+# --------------
 
 global:
-  cmt_group: cmtdev
-  cmt_node: vmpio
+  cmt_group: cavaliba
+  cmt_node: vmxupm
+  cmt_node_env: dev
+  cmt_node_role: dev_cmt
+  cmt_node_location: Ladig
   enable: yes
   enable_pager: yes
   conf_url: http://localhost/cmt/conf/
   pager_rate_limit: 3600
-  max_execution_time: 5
+  max_execution_time: 10
   load_confd: yes
+  alert_max_level: alert
+  alert_delay: 90
+
+# Remote metrology servers
+# ------------------------
+# to store and present data, with alert/warning/notice infos
 
 metrology_servers:
   graylog_test1:
       type: graylog_udp_gelf
       host: 10.10.10.13
       port: 12201
+      enable: yes
   graylog_test2:
       type: graylog_http_gelf
       url: http://10.10.10.13:8080/gelf
+      enable: yes
+
+# Pager services
+# --------------
+# to send live alerts to human
 
 pagers:
   alert:
@@ -34,12 +51,13 @@ pagers:
     url: https://outlook.office.com/webhook/xxxxxxxxxxxxxxx/IncomingWebhook/yyyyyyyyyyyyyyy
     enable: no
      
-
-# -------
-
+# List of enabled modules
+# -----------------------
 modules:
   load:
     enable: yes
+    alert_max_level: notice
+
   cpu:
     enable: yes
   memory:
@@ -48,40 +66,45 @@ modules:
     enable: yes
   boottime:
     enable: yes
-#  ntp:
-#    enable: yes
+  ntp:
+    enable: yes
   disk:
     enable: yes
   url:
     enable: yes
   mount:
     enable: yes
+    alert_max_level: notice    
   process:
     enable: yes
   ping:
     enable: yes
+    alert_max_level: warn    
   folder:
     enable: yes
+    #alert_delay: 70
+    #alert_max_level: alert
 
 
-# ------
+# List of checks to perform each time
+# -----------------------------------
 
 checks:
 
 # load
-  load:
+  my_load:
     module: load
     enable: yes
     alert_max_level: alert
 
 # cpu
-  cpu:
+  my_cpu:
     module: cpu
     enable: yes
     alert_max_level: alert
 
 # memory
-  memory:
+  my_memory:
     module: memory
     enable: yes
     alert_max_level: alert
@@ -93,35 +116,42 @@ checks:
     alert_max_level: alert
 
 # swap
-  swap:
+  my_swap:
     module: swap
     enable: yes
     alert_max_level: alert
 
 # disk  
-  disk_root:
+  my_disk_root:
     module: disk
     path: /
     alert: 80
-  disk_boot:
+  my_disk_boot:
     module: disk
     path: /boot
     alert: 90
 
 # url
-  www.cavaliba.com:
+  main_website:
     module: url
     enabled: after 2020-01-01
     url: https://www.cavaliba.com/
     pattern: "Cavaliba"
     allow_redirects: yes
     ssl_verify: yes
+    #host: toto
+  www_non_existing_for_test:
+    module: url
+    enabled: after 2020-01-01
+    url: http://www.nonexisting/
+    #pattern: ""
+
 
 #mount
-  mount_root:
+  my_mount_root:
     module: mount
     path: /
-  mount_mnt:
+  my_mount_mnt:
     module: mount
     path: /mnt
 
@@ -129,6 +159,7 @@ checks:
   redis:
     module: process
     psname: redis
+    enable_pager: no
   apache:
     module: process
     psname: httpd
@@ -147,7 +178,8 @@ checks:
   php-fpm:
     module: process
     psname: php-fpm
-    
+    enable_pager: yes
+
 # ping
   ping_vm1:
     module: ping
@@ -155,14 +187,22 @@ checks:
   ping_locahost:
     module: ping
     host: localhost
-  www.google.com:
+  ping_google:
     module: ping
     host: www.google.com
-
+  wwwtest:
+    module: ping
+    host: www.test.com    
+  badname:
+    module: ping
+    host: www.averybadnammme_indeed.com  
+    
 # folder
   folder_mytmp:
     module: folder
     path: /tmp
+    alert_max_level: alert
+    #alert_delay: 30
     target:
        is_blabla:
        #age_min: 1000
@@ -173,16 +213,14 @@ checks:
        #size_max: 10
        has_files:
             - secret.pdf
-            - secret2.pdf
+            #- secret2.pdf
   folder_number2:
     module: folder
     path: /missing
 
 
-# ------------------------------------
-# load_confd 
-# conf.d/*.yml also included with :
-# - main conf has higher priority
-# ------------------------------------
+# ---------------------------------------------------------
+# if set so in global conf.d/*.yml also included and merged
+# ---------------------------------------------------------
 
 

--- a/conf.yml.ori
+++ b/conf.yml.ori
@@ -54,40 +54,51 @@ pagers:
 # List of enabled modules
 # -----------------------
 modules:
+
   load:
     enable: yes
     alert_max_level: notice
 
   cpu:
     enable: yes
+
   memory:
     enable: yes
+
   swap:
     enable: yes
+
   boottime:
     enable: yes
+
   ntp:
     enable: yes
+
   disk:
     enable: yes
+
   url:
     enable: yes
+
   mount:
     enable: yes
     alert_max_level: notice    
+
   process:
     enable: yes
+
   ping:
     enable: yes
     alert_max_level: warn    
+
   folder:
     enable: yes
     #alert_delay: 70
     #alert_max_level: alert
 
 
-# List of checks to perform each time
-# -----------------------------------
+# List of checks to perform 
+# --------------------------
 
 checks:
 
@@ -220,7 +231,7 @@ checks:
 
 
 # ---------------------------------------------------------
-# if set so in global conf.d/*.yml also included and merged
+# if set global,  conf.d/*.yml also included and merged
 # ---------------------------------------------------------
 
 

--- a/docs/docs/check_boottime.md
+++ b/docs/docs/check_boottime.md
@@ -4,16 +4,25 @@ title: check_boottime
 
 # Boottime
 
-**BOOTTIME** collects the number of seconds and days since last reboot of the local Virtual Machine or server.
+**BOOTTIME** collects the number of seconds and days since last reboot of the local Virtual Machine or server. You can build dashboards to monitor host without reboot.
 
 ## Enable the module
 
-Enable de `boottime` check in the configuration :
+Enable de module in the configuration :
 
     # conf.yml
 
-	checks:
-  	  - boottime
+	Module:
+  	  boottime:
+  	     enable: yes
+
+### Add a check
+
+	  boottime:
+	    module: boottime
+	    enable: yes
+	    alert_max_level: alert
+
 
 ## Additional parameters
 
@@ -29,7 +38,7 @@ This module doesn't compute nor report alerts.
 
 This module sends one message with the following fields:
 
-	cmt_check: boottime
+	cmt_module: boottime
 	+
 	cmt_boottime_days: #int (days)
 	cmt_boottime_seconds: #int (seconds)
@@ -37,17 +46,11 @@ This module sends one message with the following fields:
 ## CLI usage and output
 
 	$ ./cmt.py boottime
-	--------------------------------------------------
-	CMT - Version 0.9 - (c) Cavaliba.com - 2020/10/20
-	2020/10/25 - 20:14:19 : Starting ...
-	--------------------------------------------------
-	cmt_group :  cmtdev
-	cmt_node  :  vmpio
-
+ 
 	Check boottime 
-	cmt_boottime_seconds   97880 seconds                 
-	cmt_boottime_days      1 days                        
-
-	No alerts. 
+	cmt_boottime_seconds   83790 seconds (23:16:30)  - Seconds since last reboot
+	cmt_boottime_days      0 days ()  - Days since last reboot
+	OK                     days since last reboot : 0 days - 23:16:30 sec.
+                     
 
 

--- a/docs/docs/check_certificate.md
+++ b/docs/docs/check_certificate.md
@@ -1,0 +1,9 @@
+## Enable the module
+
+### Add a check
+
+    certificate_db:
+      module: certificate
+      hostname: google.com
+      port: 2718                 # defaults to 443 if not specified
+      alert_expires_in: 1 week

--- a/docs/docs/check_certificate.md
+++ b/docs/docs/check_certificate.md
@@ -1,9 +1,40 @@
-## Enable the module
+Opens a socket to `hostname:port` and retrieve certificate information (with
+`.getpeercert()`).
 
 ### Add a check
 
     certificate_db:
       module: certificate
-      hostname: google.com
+      hostname: hostname.com
       port: 2718                 # defaults to 443 if not specified
       alert_expires_in: 1 week
+
+
+- `hostname`: the hostname
+- `port`: the port to connect the socket to
+- `alert_expires_in`: [`<duration>`](/docs/duration.md), sends an alert if
+  expiry date (`notAfter` field) is less that `<duration>` away.
+
+## Alerts
+
+Sends an alert if a certificate is invalid, that is, one of these condition
+matches:
+
+1. `expiry date - now < alert_expires_in`
+2. `now < notBefore` (notBefore is the timestamp at which the certificate will
+   become valid)
+3. No certificate is found
+4. The connection to `hostname:port` can't be established.
+
+
+## Output to ElasticSearch
+
+    cmt_certificate_hostname                 string
+    cmt_certificate_port                     int
+    certificate_expires_in                   int (seconds)
+
+    certificate_issuer_common_name           string
+    certificate_issuer_organization_name     string
+
+    certificate_subject_common_name          string
+    certificate_subject_organization_name    string

--- a/docs/docs/check_cpu.md
+++ b/docs/docs/check_cpu.md
@@ -8,12 +8,20 @@ title: check_cpu
 
 ## Enable the module
 
-Enable de `cpu` module in the configuration :
+Enable de module in the configuration :
 
     # conf.yml
 
-	checks:
-  	  - cpu
+	Module:
+  	  cpu:
+  	     enable: yes
+
+### Add a check
+
+	  mycpucheck:
+	    module: cpu
+	    enable: yes
+	    alert_max_level: notice
 
 ## Additional parameters
 
@@ -36,16 +44,10 @@ This module sends one message with the following fields:
 ## CLI usage and output
 
 	/dev/cmt_monitor$ ./cmt.py cpu
-	--------------------------------------------------
-	CMT - Version 0.9 - (c) Cavaliba.com - 2020/10/20
-	2020/10/25 - 17:27:16 : Starting ...
-	--------------------------------------------------
-	cmt_group :  cmtdev
-	cmt_node  :  vmpio
 
 	Check cpu 
-	cmt_cpu                11.8 %                        
+	cmt_cpu                13.5 % ()  - CPU Percentage
+	OK                     usage : 13.5 %
 
-	No alerts. 
 
 

--- a/docs/docs/check_disks.md
+++ b/docs/docs/check_disks.md
@@ -7,24 +7,30 @@ title: check_disks
 **DISKS** checks one or more disk capacity on Linux filesystem, as returned by `df -k` command.
 
 
-## Enable the check
+## Enable the module
 
-Enable de `disks` check in the configuration :
+Enable de module in the configuration :
 
     # conf.yml
-	checks:
-  	  - disks
+
+	Module:
+  	  disk:
+  	     enable: yes
+
+### Add a check
+
+    disk_root:
+      module: disk
+      path: /
+      alert: 80
+
 
 ## Additional parameters
 
 This check requires additional parameters to define each disk to be checked :
 
-	# conf.py
-	disks:
-	  - path: /
-	    alert: 94
-	  - path: /home
-	    alert: 70
+* path 
+* alert threshold (percentage)
 
 The first parameter is the name of the disk (df -k).
 The second parameter is the percent threshold before sending an alert.
@@ -32,11 +38,6 @@ The second parameter is the percent threshold before sending an alert.
 ## Alerts
 
 This check sends an alert and adds alert fields if a mount point is not present.
-
-output:
-
-	cmt_alert: yes
-	cmt_alert_message: string
 
 
 ## Output to ElasticSearch
@@ -52,21 +53,23 @@ This module sends one message for each mount point, with the following fields:
 
 ## CLI usage and output
 
-	$ ./cmt.py disks
-	--------------------------------------------------
-	CMT - Version 0.9 - (c) Cavaliba.com - 2020/10/20
-	2020/10/25 - 20:28:31 : Starting ...
-	--------------------------------------------------
-	cmt_group :  cmtdev
-	cmt_node  :  vmpio
+	$ ./cmt.py disk
 
 	Check disk 
-	cmt_disk               /                             
-	cmt_disk_total         67595886592 bytes (67.6 GB)   
-	cmt_disk_free          51310575616 bytes (51.3 GB)   
-	cmt_disk_percent       20.0 %               
+	cmt_disk               /  ()  - Path
+	cmt_disk_total         67370528768 bytes (67.4 GB)  - Total (Bytes)
+	cmt_disk_used          20698943488 bytes (20.7 GB)  - Used (Bytes)
+	cmt_disk_free          43218939904 bytes (43.2 GB)  - Free (Bytes)
+	cmt_disk_percent       32.4 % ()  - Used (percent)
+	OK                     path : / - used: 32.4 % - used: 20.7 GB - free: 43.2 GB - total: 67.4 GB 
 
-	No alerts. 
+	Check disk 
+	cmt_disk               /boot  ()  - Path
+	cmt_disk_total         67370528768 bytes (67.4 GB)  - Total (Bytes)
+	cmt_disk_used          20698943488 bytes (20.7 GB)  - Used (Bytes)
+	cmt_disk_free          43218939904 bytes (43.2 GB)  - Free (Bytes)
+	cmt_disk_percent       32.4 % ()  - Used (percent)
+	OK                     path : /boot - used: 32.4 % - used: 20.7 GB - free: 43.2 GB - total: 67.4 GB 
 
 
 

--- a/docs/docs/check_folders.md
+++ b/docs/docs/check_folders.md
@@ -9,13 +9,15 @@ title: check_folders
 It can check for existence, size, number of files, file size, file age, or existing filenames inside the folders. It can scan recursively subfolders.
 
 
-## Enable the check
+## Enable the module
 
-Enable de `folders` check in the configuration :
+Enable de module in the configuration :
 
     # conf.yml
-	checks:
-  	  - folders
+
+	Module:
+  	  folder:
+  	     enable: yes
 
 ## Additional parameters
 
@@ -67,10 +69,6 @@ Targets define the desired state of a folder.
 
 This check sends an alert and adds alert fields if a folder doesn't match its target state.
 
-output:
-
-	cmt_alert: yes
-	cmt_alert_message: string
 
 Alert message:
 
@@ -103,38 +101,22 @@ This module sends one message for each mount point, with the following fields:
 ## CLI usage and output
 
 	$ ./cmt.py folders
-	--------------------------------------------------
-	CMT - Version 0.9 - (c) Cavaliba.com - 2020/10/20
-	2020/10/25 - 21:08:44 : Starting ...
-	--------------------------------------------------
-	cmt_group :  cmtdev
-	cmt_node  :  vmpio
 
 	Check folder 
-	cmt_folder_path        /tmp                          
-	cmt_folder_name        mytmp                         
-	cmt_folder_files       3                             
-	cmt_folder_dirs        21                            
-	cmt_folder_size        409 bytes (409.0 B)           
-	cmt_folder_age_min     1017   sec                    
-	cmt_folder_age_max     101134 sec                    
-	cmt_folder_status      NOK                  
+	cmt_folder_path        /tmp  () 
+	cmt_folder_name        /tmp  () 
+	cmt_folder_files       3 files ()  - Number of files in folder /tmp
+	cmt_folder_dirs        15 dirs ()  - Number of dirs/subdirs in folder /tmp
+	cmt_folder_size        425 bytes (425.0 B)  - Total Size (bytes)
+	cmt_folder_age_min     84283 sec ()  - Min age (seconds)
+	cmt_folder_age_max     84478 sec ()  - Max age (seconds)
+	NOK                    /tmp : expected file not found (secret.pdf)
 
 	Check folder 
-	cmt_folder_path        /tmp/absent                   
-	cmt_folder_name        numbertwo                     
-	cmt_folder_status      NOK                  
+	cmt_folder_path        /missing  () 
+	cmt_folder_name        /missing  () 
+	NOK                    /missing missing
 
-	Check folder 
-	cmt_folder_path        /tmp/empty                    
-	cmt_folder_name        number3                       
-	cmt_folder_status      NOK                  
-
-	Alerts : 
-	--------
-	check_folder - /tmp : expected file not found (aaa.txt)
-	check_folder - /tmp/absent missing
-	check_folder - /tmp/empty missing
 
 
 

--- a/docs/docs/check_load.md
+++ b/docs/docs/check_load.md
@@ -9,12 +9,13 @@ title: check_load
 
 ## Enable the module
 
-Enable de `load` module in the configuration :
+Enable de module in the configuration :
 
     # conf.yml
 
-	checks:
-  	  - load
+	Module:
+  	  load:
+  	     enable: yes
 
 ## Additional parameters
 
@@ -41,17 +42,10 @@ This module sends one message with the following fields:
 
 	/dev/cmt_monitor$ ./cmt.py load
 
-	--------------------------------------------------
-	CMT - Version 0.9 - (c) Cavaliba.com - 2020/10/20
-	2020/10/25 - 17:24:04 : Starting ...
-	--------------------------------------------------
-	cmt_group :  cmtdev
-	cmt_node  :  vmpio
-
 	Check load 
-	cmt_load1              0.48                          
-	cmt_load5              0.43                          
-	cmt_load15             0.35                          
+	cmt_load1              0.55  ()  - CPU Load Average, one minute
+	cmt_load5              0.57  ()  - CPU Load Average, 5 minutes
+	cmt_load15             0.6  ()  - CPU Load Average, 15 minutes
+	OK                     1/5/15 min : 0.55  0.57  0.6
 
-	No alerts. 
 

--- a/docs/docs/check_memory.md
+++ b/docs/docs/check_memory.md
@@ -8,12 +8,13 @@ title: check_memory
 
 ## Enable the module
 
-Enable de `memory` check in the configuration :
+Enable de module in the configuration :
 
     # conf.yml
 
-	checks:
-  	  - memory
+	Module:
+  	  memory:
+  	     enable: yes
 
 ## Additional parameters
 
@@ -38,19 +39,14 @@ This module sends one message with the following fields:
 ## CLI usage and output
 
 	$ ./cmt.py memory
-	--------------------------------------------------
-	CMT - Version 0.9 - (c) Cavaliba.com - 2020/10/20
-	2020/10/25 - 20:10:56 : Starting ...
-	--------------------------------------------------
-	cmt_group :  cmtdev
-	cmt_node  :  vmpio
-
+	
 	Check memory 
-	cmt_memory_percent     85.8 %                        
-	cmt_memory_used        1557790720 bytes (1.6 GB)     
-	cmt_memory_available   296288256 bytes (296.3 MB)    
+	cmt_memory_percent     86.1 % ()  - Memory used (percent)
+	cmt_memory_used        2031271936 bytes (2.0 GB)  - Memory used (bytes)
+	cmt_memory_available   382902272 bytes (382.9 MB)  - Memory available (bytes)
+	cmt_memory_total       2749349888 bytes (2.7 GB)  - Memory total (bytes)
+	OK                     used 86.1 % - used 2.0 GB - avail 382.9 MB - total 2.7 GB
 
-	No alerts. 
 
 
 

--- a/docs/docs/check_mounts.md
+++ b/docs/docs/check_mounts.md
@@ -6,33 +6,32 @@ title: check_mounts
 
 **Mounts** checks if one or more mount point in Linux filesystem are present.
 
-## Enable the check
+## Enable the module
 
-Enable de `mounts` check in the configuration :
+Enable de module in the configuration :
 
     # conf.yml
-	checks:
-  	  - mounts
+
+	Module:
+  	  mount:
+  	     enable: yes
 
 ## Additional parameters
 
 This check requires additional parameters to define each mount point to be checked :
 
-	# conf.py
-	mounts:
-	  - /
-	  - /boot
-	  - /mnt/export
-	  - /home
+	#mount
+	  mount_root:
+	    module: mount
+	    path: /
+	  mount_mnt:
+	    module: mount
+	    path: /mnt
+
 
 ## Alerts
 
 This check sends an alert and adds alert fields if a mount point is not present.
-
-output:
-
-	cmt_alert: yes
-	cmt_alert_message: string
 
 
 ## Output to ElasticSearch
@@ -47,24 +46,19 @@ This module sends one message for each mount point, with the following fields:
 ## CLI usage and output
 
 	$ ./cmt.py mounts
-	--------------------------------------------------
-	CMT - Version 0.9 - (c) Cavaliba.com - 2020/10/20
-	2020/10/25 - 20:18:27 : Starting ...
-	--------------------------------------------------
-	cmt_group :  cmtdev
-	cmt_node  :  vmpio
 
 	Check mount 
-	cmt_mount              /                             
-	cmt_mount_status       OK                   
+	cmt_mount              /  () 
+	OK                     path / found
 
 	Check mount 
-	cmt_mount              /boot                         
-	cmt_mount_status       NOK                  
+	cmt_mount              /mnt  () 
+	NOTICE                 path /mnt not found
 
-	Alerts : 
-	--------
-	check_mount - /boot not found
+	Check mount 
+	cmt_mount              /merge  () 
+	NOTICE                 path /merge not found
+
 
 
 

--- a/docs/docs/check_pings.md
+++ b/docs/docs/check_pings.md
@@ -4,36 +4,43 @@ title: check_pings
 
 # Pings
 
-**PINGS** checks if one or more host is reachable by standard ping command..
+**PING** checks if one or more host is reachable by standard ping command.
 
-## Enable the check
+## Enable the module
 
-Enable de `pings` check in the configuration :
+Enable de module in the configuration :
 
     # conf.yml
-	checks:
-  	  - pings
+
+	Module:
+  	  ping:
+  	     enable: yes
 
 ## Additional parameters
 
 This check requires additional parameters to define each mount point to be checked :
 
-	# conf.py
-	pings:
-	  - 192.168.0.1
-	  - localhost
-	  - 127.0.0.1
-	  - www.cavaliba.com
+	# ping
+	  ping_vm1:
+	    module: ping
+	    host: 192.168.0.1
+	  ping_locahost:
+	    module: ping
+	    host: localhost
+	  www.google.com:
+	    module: ping
+	    host: www.google.com
+	  wwwtest:
+	    module: ping
+	    host: www.test.com    
+	  badname:
+	    module: ping
+	    host: www.averybadnammme_indeed.com  
 
 
 ## Alerts
 
 This check sends an alert and adds alert fields if a mount point is not present.
-
-output:
-
-	cmt_alert: yes
-	cmt_alert_message: string (not responding)
 
 
 ## Output to ElasticSearch
@@ -48,30 +55,27 @@ This module sends one message for each mount point, with the following fields:
 ## CLI usage and output
 
 	$ ./cmt.py pings
-	--------------------------------------------------
-	CMT - Version 0.9 - (c) Cavaliba.com - 2020/10/20
-	2020/10/25 - 21:19:17 : Starting ...
-	--------------------------------------------------
-	cmt_group :  cmtdev
-	cmt_node  :  vmpio
 
 	Check ping 
-	cmt_ping               192.168.0.1                   
-	cmt_ping_status        OK                   
+	cmt_ping               192.168.0.1  () 
+	OK                     192.168.0.1 ok
 
 	Check ping 
-	cmt_ping               localhost                     
-	cmt_ping_status        OK                   
+	cmt_ping               localhost  () 
+	OK                     localhost ok
 
 	Check ping 
-	cmt_ping               127.0.0.1                     
-	cmt_ping_status        OK                   
+	cmt_ping               www.google.com  () 
+	OK                     www.google.com ok
 
 	Check ping 
-	cmt_ping               www.cavaliba.com                
-	cmt_ping_status        OK                   
+	cmt_ping               www.test.com  () 
+	WARN                   www.test.com not responding
 
-	No alerts. 
+	Check ping 
+	cmt_ping               www.averybadnammme_indeed.com  () 
+	WARN                   www.averybadnammme_indeed.com not responding
+
 
 
 

--- a/docs/docs/check_process.md
+++ b/docs/docs/check_process.md
@@ -7,34 +7,46 @@ title: check_process
 **PROCESS** checks if one or more process is running.
 
 
-## Enable the check
+## Enable the module
 
-Enable de `process` check in the configuration :
+Enable de module in the configuration :
 
     # conf.yml
-	checks:
-  	  - process
+
+	Module:
+  	  process:
+  	     enable: yes
 
 ## Additional parameters
 
 This check requires additional parameters to define each disk to be checked :
 
-	# conf.py
-	process:
-	  - name: redis
+
+	# process
+	  redis:
+	    module: process
 	    psname: redis
-	  - name: apache2
+	    enable_pager: no
+	  apache:
+	    module: process
 	    psname: httpd
-	  - name: cron
+	  cron:
+	    module: process
 	    psname: cron
-	  - name: sshd
+	  ssh:
+	    module: process
 	    psname: sshd
-	  - name: ntp
-	    psname: chronyd
-	  - name: mysqld
+	  ntp:
+	    module: process
+	    psname: ntpd
+	  mysql:
+	    module: process
 	    psname: mysqld
-	  - name: php-fpm
-	    psname: php72-fpm
+	  php-fpm:
+	    module: process
+	    psname: php-fpm
+	    enable_pager: yes
+
 
 
 The first parameter is the name of the process to be reported to cental server.
@@ -44,10 +56,6 @@ The second parameter is the exact process name to be checked in the process list
 
 This check sends an alert and adds alert fields if a process is not running.
 
-output:
-
-	cmt_alert: yes
-	cmt_alert_message: string
 
 
 ## Output to ElasticSearch
@@ -64,53 +72,41 @@ This module sends one message for each mount point, with the following fields:
 ## CLI usage and output
 
 	$ ./cmt.py process
-	--------------------------------------------------
-	CMT - Version 0.9 - (c) Cavaliba.com - 2020/10/20
-	2020/10/25 - 20:33:22 : Starting ...
-	--------------------------------------------------
-	cmt_group :  cmtdev
-	cmt_node  :  vmpio
 
 	Check process 
-	cmt_process_name       redis                         
-	cmt_process_status     NOK                  
+	cmt_process_name       redis  () 
+	NOK                    redis missing (redis)
 
 	Check process 
-	cmt_process_name       apache2                        
-	cmt_process_status     NOK                  
+	cmt_process_name       apache  () 
+	NOK                    apache missing (httpd)
 
 	Check process 
-	cmt_process_name       cron                          
-	cmt_process_status     OK                   
-	cmt_process_memory     618496 bytes (618.5 KB)       
-	cmt_process_cpu        0.07 seconds                  
+	cmt_process_name       cron  () 
+	cmt_process_memory     2899968 bytes (2.9 MB)  - rss
+	cmt_process_cpu        0.04 seconds (0:00:00)  - cpu time, user
+	OK                     cron found (cron) - memory rss 2.9 MB - cpu 0.04 sec.
 
 	Check process 
-	cmt_process_name       sshd                          
-	cmt_process_status     OK                   
-	cmt_process_memory     2772992 bytes (2.8 MB)        
-	cmt_process_cpu        0.02 seconds                  
+	cmt_process_name       ssh  () 
+	cmt_process_memory     3899392 bytes (3.9 MB)  - rss
+	cmt_process_cpu        0.05 seconds (0:00:00)  - cpu time, user
+	OK                     ssh found (sshd) - memory rss 3.9 MB - cpu 0.05 sec.
 
 	Check process 
-	cmt_process_name       ntp                          
-	cmt_process_status     NOK                  
+	cmt_process_name       ntp  () 
+	NOK                    ntp missing (ntpd)
 
 	Check process 
-	cmt_process_name       mysqld                        
-	cmt_process_status     OK                   
-	cmt_process_memory     0 bytes (0.0 B)               
-	cmt_process_cpu        11.71 seconds                 
+	cmt_process_name       mysql  () 
+	cmt_process_memory     56307712 bytes (56.3 MB)  - rss
+	cmt_process_cpu        20.76 seconds (0:00:20)  - cpu time, user
+	OK                     mysql found (mysqld) - memory rss 56.3 MB - cpu 20.76 sec.
 
 	Check process 
-	cmt_process_name       php72-fpm                       
-	cmt_process_status     NOK                  
+	cmt_process_name       php-fpm  () 
+	NOK                    php-fpm missing (php-fpm)
 
-	Alerts : 
-	--------
-	check_process - redis missing (redis)
-	check_process - apache missing (httpd)
-	check_process - ntpd missing (ntpd)
-	check_process - php-fpm missing (php-fpm)
 
 
 

--- a/docs/docs/check_swap.md
+++ b/docs/docs/check_swap.md
@@ -8,12 +8,13 @@ title: check_swap
 
 ## Enable the module
 
-Enable de `swap` check in the configuration :
+Enable de module in the configuration :
 
     # conf.yml
 
-	checks:
-  	  - swap
+	Module:
+  	  swap:
+  	     enable: yes
 
 ## Additional parameters
 
@@ -32,21 +33,17 @@ This module sends one message with the following fields:
 	cmt_check: swap
 	+
 	cmt_swap_used: #int (bytes)
+	cmt_swap_total: #int (bytes)
 	cmt_swap_percent: #float (percent)
 
 ## CLI usage and output
 
 	$ ./cmt.py swap
-	--------------------------------------------------
-	CMT - Version 0.9 - (c) Cavaliba.com - 2020/10/20
-	2020/10/25 - 20:12:33 : Starting ...
-	--------------------------------------------------
-	cmt_group :  cmtdev
-	cmt_node  :  vmpio
 
 	Check swap 
-	cmt_swap_percent       34.3 %                        
-	cmt_swap_used          736362496 bytes (736.4 MB)    
+	cmt_swap_percent       13.9 % ()  - Swap used (percent)
+	cmt_swap_used          297443328 bytes (297.4 MB)  - Swap used (bytes)
+	cmt_swap_total         2147479552 bytes (2.1 GB)  - Swap total (bytes)
+	OK                     used: 13.9 % /  297.4 MB - total 2.1 GB
 
-	No alerts. 
 

--- a/docs/docs/check_urls.md
+++ b/docs/docs/check_urls.md
@@ -2,42 +2,51 @@
 title: check_urls
 ---
 
-# Urls
+# Url
 
-**URLS** checks if one or more *Url* can 
+**URL** checks if one or more *Url* can 
 
 - be contacted before a timeout, 
--  provides an http response code of 200 (OK)
--  contains a specific pattern / string in the body of the response.
+- provides an http response code of 200 (OK)
+- contains a specific pattern / string in the body of the response.
 
 It can verify TLS/SSL certificates.
 It can follow redirets.
 It reports URL response time.
+It can pass a Host header to query specfic virtual-host.
 
 This check can be used from a remote server to monitor various URL and Webservices. It can also be configured locally on a single Webserver to monitor a local single instance. If the provided URL is an application status (e.g. php-fpm /status with pattern "pong"), you can have a basic (or not so basic) application monitor.
 
-## Enable the check
+## Enable the module
 
-Enable de `urls` check in the configuration :
+Enable de module in the configuration :
 
     # conf.yml
-	checks:
-  	  - urls
+
+	Module:
+  	  url:
+  	     enable: yes
 
 ## Additional parameters
 
 This check requires additional parameters to define each URL to be checked :
 
 	# conf.py
-	urls:
-	  - url: https://www.cavaliba.com/
-	    name: www.cavaliba.com
+	# url
+	  www.cavaliba.com:
+	    module: url
+	    enabled: after 2020-01-01
+	    url: https://www.cavaliba.com/
 	    pattern: "Cavaliba"
 	    allow_redirects: yes
 	    ssl_verify: yes
-	  - url: http://demo.cavaliba.com/
-	    name: demo.cavaliba.com
-	    pattern: "SIRENE"
+	    #host: toto
+	  www_non_existing:
+	    module: url
+	    enabled: after 2020-01-01
+	    url: http://www.nonexisting/
+	    #pattern: ""
+
 
 pattern: 
 	
@@ -55,11 +64,6 @@ ssl_verify:
 ## Alerts
 
 This check sends an alert and adds alert fields if an URL isn't responding properly.
-
-output:
-
-	cmt_alert: yes
-	cmt_alert_message: string
 
 Alert message:
 
@@ -81,20 +85,24 @@ This module sends one message for each mount point, with the following fields:
 ## CLI usage and output
 
 	$ ./cmt.py urls
-	--------------------------------------------------
-	CMT - Version 0.9 - (c) Cavaliba.com - 2020/10/20
-	2020/10/25 - 20:40:36 : Starting ...
-	--------------------------------------------------
-	cmt_group :  cmtdev
-	cmt_node  :  vmpio
 
 	Check url 
-	cmt_url_name           demo.cavaliba.com             
-	cmt_url                http://demo.cavaliba.com/     
-	cmt_url_msec           227 ms                        
-	cmt_url_status         OK                   
+	cmt_url_name           www.cavaliba.com  () 
+	cmt_url                https://www.cavaliba.com/  () 
+	cmt_url_msec           96 ms () 
+	OK                     www.cavaliba.com - https://www.cavaliba.com/ [Host: ] - http=200 - 96 ms ; pattern OK
 
-	No alerts. 
+	Check url 
+	cmt_url_name           www_non_existing  () 
+	cmt_url                http://www.nonexisting/  () 
+	NOK                    www_non_existing - http://www.nonexisting/ [Host: ] - no response to query
+
+	Check url 
+	cmt_url_name           demo.cavaliba.com  () 
+	cmt_url                http://demo.cavaliba.com/  () 
+	cmt_url_msec           187 ms () 
+	OK                     demo.cavaliba.com - http://demo.cavaliba.com/ [Host: ] - http=200 - 187 ms ; pattern OK
+
 
 
 

--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -1,0 +1,124 @@
+---
+title: CLI
+---
+
+# CMT used in command-line mode (CLI)
+
+
+    $ ./cmt.py -h
+    usage: cmt.py [-h] [--report] [--pager] [--persist] [--conf CONF]
+                  [--pagertest] [--no-pager-rate-limit] [--checkconfig]
+                  [--version] [--debug] [--debug2] [--short] [--devmode]
+                  [--listmodules] [--available]
+                  [modules [modules ...]]
+
+    CMT - Cavaliba Monitoring
+
+    positional arguments:
+      modules               modules to check
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      --report              send events to Metrology servers
+      --pager               send alerts to Pagers
+      --persist             persist data accross CMT runs (use in cron)
+      --conf CONF           specify alternate yaml config file
+      --pagertest           send test message to teams and exit
+      --no-pager-rate-limit
+                            disable pager rate limit
+      --checkconfig         checkconfig and exit
+      --version, -v         display current version
+      --debug               verbose/debug output
+      --debug2              more debug
+      --short, -s           short compact cli output
+      --devmode             dev mode, no pager, no remote metrology
+      --listmodules         display available modules
+      --available           display available entries found for modules (manual
+                            run on target)
+
+## Full run, short output
+
+    $ ./cmt.py -s
+    ------------------------------------------------------------
+    CMT - Version 1.0.0 - (c) Cavaliba.com - 2020/11/29
+    ------------------------------------------------------------
+    2020/11/29 - 15:59:08 : Starting ...
+    cmt_group      :  cavaliba
+    cmt_node       :  vmxupm
+
+    Short output
+    ------------
+
+    OK      load       1/5/15 min : 0.44  0.46  0.53
+    OK      cpu        usage : 10.8 %
+    OK      memory     used 85.2 % - used 2.0 GB - avail 406.8 MB - total 2.7 GB
+    OK      boottime   days since last reboot : 0 days - 23:35:57 sec.
+    OK      swap       used: 13.9 % /  297.4 MB - total 2.1 GB
+    OK      disk       path : / - used: 32.4 % - used: 20.7 GB - free: 43.2 GB - total: 67.4 GB 
+    OK      disk       path : /boot - used: 32.4 % - used: 20.7 GB - free: 43.2 GB - total: 67.4 GB 
+    OK      url        www.cavaliba.com - https://www.cavaliba.com/ [Host: ] - http=200 - 103 ms ; pattern OK
+    NOK     url        www_non_existing - http://www.nonexisting/ [Host: ] - no response to query
+    OK      mount      path / found
+    NOTICE  mount      path /mnt not found
+    NOK     process    redis missing (redis)
+    NOK     process    apache missing (httpd)
+    OK      process    cron found (cron) - memory rss 2.9 MB - cpu 0.04 sec.
+    OK      process    ssh found (sshd) - memory rss 3.9 MB - cpu 0.05 sec.
+    NOK     process    ntp missing (ntpd)
+    OK      process    mysql found (mysqld) - memory rss 56.3 MB - cpu 20.83 sec.
+    NOK     process    php-fpm missing (php-fpm)
+    OK      ping       192.168.0.1 ok
+    OK      ping       localhost ok
+    OK      ping       www.google.com ok
+    WARN    ping       www.test.com not responding
+    WARN    ping       www.averybadnammme_indeed.com not responding
+    NOK     folder     /tmp : expected file not found (secret.pdf)
+    NOK     folder     /missing missing
+    NOTICE  mount      path /merge not found
+    OK      url        demo.cavaliba.com - http://demo.cavaliba.com/ [Host: ] - http=200 - 181 ms ; pattern OK
+
+    Notification Summary
+    --------------------
+
+    Notice 
+    mount           : path /mnt not found
+    mount           : path /merge not found
+
+    Warnings 
+    ping            : www.test.com not responding
+    ping            : www.averybadnammme_indeed.com not responding
+
+    Alerts 
+    url             : www_non_existing - http://www.nonexisting/ [Host: ] - no response to query
+    process         : redis missing (redis)
+    process         : apache missing (httpd)
+    process         : ntp missing (ntpd)
+    process         : php-fpm missing (php-fpm)
+    folder          : /tmp : expected file not found (secret.pdf)
+    folder          : /missing missing
+
+    2020/11/29 - 15:59:12 : Done.
+
+
+## Limit to one module
+
+    $ ./cmt.py -s process
+
+    ------------------------------------------------------------
+    CMT - Version 1.0.0 - (c) Cavaliba.com - 2020/11/29
+    ------------------------------------------------------------
+    2020/11/29 - 15:59:53 : Starting ...
+    cmt_group      :  cavaliba
+    cmt_node       :  vmxupm
+
+    Short output
+    ------------
+
+    NOK     process    redis missing (redis)
+    NOK     process    apache missing (httpd)
+    OK      process    cron found (cron) - memory rss 2.9 MB - cpu 0.04 sec.
+    OK      process    ssh found (sshd) - memory rss 3.9 MB - cpu 0.05 sec.
+    NOK     process    ntp missing (ntpd)
+    OK      process    mysql found (mysqld) - memory rss 56.3 MB - cpu 20.84 sec.
+    NOK     process    php-fpm missing (php-fpm)
+

--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -44,40 +44,197 @@ Each additional file must be a valid
 
 ## Configuration structure
 
-The complete configuration for a CMT run has 3 sections :
+The complete configuration for a CMT run has 5 sections :
 
-1. a global configuration section
-2. a list of checks that are enabled
-3. specific parameters for each item to be monitored (check dependent)
+1. a global section (global)
+2. a metrology server section
+3. a pager servers section
+4. a module secion  to enable/disable various modules
+5. a checks section with all  individual checks parameters (module dependent)
 
 
-## Global configuration
+## Configuration Reference 
 
-	cmt_group: cmtdev
-	cmt_node: vmpio
+	===========================================================
+	Configuration Reference
+	===========================================================
 
-	# GELF/Elastic servers for data reports
-    # -------------------------------------	
-	graylog_udp_gelf_servers:
-	  - name: graylog_test
-	    host: 10.10.10.13
-	    port: 12201
+	[ ] is optional, available
+	( ) is on the roadmap
 
-	graylog_http_gelf_servers:
-	  - name: graylog_test
-	    url: http://10.10.10.13:8080/gelf
 
-	# Teams channels for alerts
-	# ---------------------------
+	--------------------------------
+	timerange field
+	--------------------------------
+	- yes
+	- no
+	- after YYYY-MM-DD hh:mm:ss
+	- before YYYY-MM-DD hh:mm:ss
+	- hrange hh:mm:ss hh:mm:ss
+	- ho   (8h30/18h mon>fri)
+	- hno  (! (8h30/18h mon>fri))
 
-	teams_channel:
-	   - name: alert
-	     url: https://outlook.office.com/webhook/xxxx(...)xxxx/IncomingWebhook/yyyy(...)
-	   - name: test
-	     url: https://outlook.office.com/webhook/xxxx(...)xxx/IncomingWebhook/yyyy(...)yyy
+	----------------------
+	Global
+	----------------------
 
-	# Rate limit message to Teams to max one every XX seconds
-	teams_rate_limit: 3600
+	global:
+	  cmt_group: cavaliba
+	  cmt_node: dev_vm1
+
+	  [cmt_node_env]       : string: prod, dev, qa, test, form, preprod, qualif ...
+	  [cmt_node_role]      : string ; appli_front_1, db_3
+	  [cmt_node_location]  : string, geographical position
+
+	  [enable]             : timerange ; DEFAULT = yes; master switch (no inheritance)
+	  [enable_pager]       : timerange ; DEFAULT = no ; master switch (no inheritance)
+	  [pager_rate_limit]   : seconds ; default 7200
+	  [conf_url]           : https://.../api/  (/group_node.txt if url ends by /)
+	  [max_execution_time] : seconds ; DEFAULT 5
+	  [load_confd]         : yes/no ; DEFAULT no
+	  [alert_max_level]    : alert, warn, notice   ; lower priority ;
+	  [alert_delay]        : delay before transition to alert (if alert) ; seconds/DEFAULT 120 
+
+
+	----------------------
+	Metrology Servers
+	----------------------
+
+	metrology_servers:
+
+	  graylog_test1:
+	      type: graylog_udp_gelf
+	      host: 10.10.10.13
+	      port: 12201
+	  graylog_test2:
+	      type: graylog_tcp_gelf
+	      url: http://10.10.10.13:8080/gelf
+
+	      [enable]                : timerange ; default = yes ; master switch      
+	      ()secret_key
+
+	----------------------
+	Pager services
+	----------------------
+
+	pagers:
+	  alert              : mandatory entry 'alert'
+	     type            : team_channel
+	     url             : Teams channel URL
+	     [enable]        : timerange ; DEFAULT = no ; master switch / no inheritance
+	     ()secret_key    : 
+	     ()add_tags
+	         tag: value
+	         tag: value
+	  test               : mandatory 'test' entry for ARG --pagertest
+	     type            : team_channel
+	     url             :   
+	     [enable]        : timerange ; DEFAULT = no  test:
+	     ()secret_key    : 
+
+
+	---------------------------
+	Modules
+	---------------------------
+	modules are enabled by default
+
+	modules:
+	  name:               : module name : ex load , cpu, swap, ...
+	    enable            : timerange ; default yes
+	  name:               : load 
+	    enable            : timerange ; default yes
+	    [alert_max_level] : alert, warn, notice (scale down)  ; overwrites global entry
+	    [alert_delay]     : delay before transition from to alert ; seconds/DEFAULT 120 
+	    ()[frequency]     : min seconds between runs ; needs --persist in ARGS
+
+
+	--------------------------
+	Checks instances
+	--------------------------
+
+	general check config
+	---------------------
+	checks
+	  checkname             : string - unique id
+	      module            : module name (load, cpu, url)
+	      arg1              : specific to module
+	      arg2              : specific to module  
+	      (...)
+
+	      [enable]          : timerange ; default yes  
+	      [alert_max_level] : alert, warn, notice (scales down) ; overwrites global / module
+	      [enable_pager]    : timerange ; default NO ; need global/pager to be enabled 
+
+	      [alert_delay]     : delay before alert ; DEFAULT 120 
+
+
+	specific check options
+	----------------------
+	load:
+	  module : load
+
+	cpu:
+	  module : cpu
+
+	swap:
+	  module : swap
+
+	memory:
+	  module : memory
+
+	boottime
+	  module : boottime  
+
+	mount:
+	  module        : mount
+	  path          : /path/to/mountpoint
+
+	disk:
+	  module        : disk
+	  path          : /absolute/path
+	  alert         : INT [percent before alert]
+
+	process
+	  module        : process
+	  psname        : string  (system process name)
+
+	url:
+	  module            : url
+	  url               : https://www.cavaliba.com/
+	  [pattern]         : "Cavaliba" ; DEFAULT = ""
+	  [allow_redirects] : yes ; default = no
+	  [ssl_verify]      : yes ; default = no
+	  [host]            : optionnal hostname header (Host: xxx)
+
+
+	ping
+	   module          : ping
+	   host            : 192.168.0.1
+	 
+
+	folder
+	  module            : folder
+	  folder_name       : string, unique value
+	  path              : /path/to/folder
+	  recursive         : yes  ; default = no
+	  ()[]filter: *.txt : TODO 
+	  [target:
+	     files_max       : 400
+	     files_min       : 2
+	     size_max:       : (folder)
+	     size_min:       : (folder)      
+	     age_max:        : seconds, (file)
+	     age_min:        : seconds (file)
+	     has_files: 
+	         - filename1
+	         - filename2
+	     ()min_bytes:    : TODO (file)
+	     ()max_bytes:    : TODO
+	   ]
+
+
+## Global Section
+*new v1.0.0* : all entries in the global section must be under **global** yaml top entry.
 
 
 ### cmt_group
@@ -97,93 +254,94 @@ This field is sent as-is in every JSON message sent by CMT running the configura
 It may be the name of the Server or Virtual Machine.
 
 	# conf.yml
-	cmt_group: node-05-france-lyon
+	cmt_group: node-05-france-grignan
+
+### cmt_node_role
+*new v1.0.0*
+Optional.
 
 
-###	graylog_udp_gelf_servers
+### cmt_node_env
+*new v1.0.0*
+Optional.
 
-A list of one or more remote (or local) server which accept standardized GELF UDP message. 
+
+### cmt_node_location
+*new v1.0.0*
+Optional.
+
+
+###	metrology_servers
+
+A list of one or more remote (or local) server which accept standardized GELF/Elastic/Graylog message over UDP or HTTP.
 
 Every GELF server will receive all message sent by CMT.
 
 GELF is basically JSON with a few mandatory fields.
 
-GELF over UDP (here) has low/no security. Data in the clear ...
+GELF over UDP is the simpler and more efficient protocol. UDP has no coupling between the client (CMT) and the server (GRAYLOG/Logstash/Elastic). It's fire'n forget. GELF over UDP (here) has low/no security. Data in the clear ...
 
-This is the simpler and more efficient protocol. UDP has no coupling between the client (CMT) and the server (GRAYLOG/Logstash/Elastic). It's fire'n forget.
-
-See Graylog/GELF documentation for more information.
-
-	# conf.yml
-	graylog_udp_gelf_servers:
-	  - name: graylog_test
-	    host: 10.10.10.13
-	    port: 12201
-	  - name: graylog_test2
-	    host: 10.10.10.14
-	    port: 12201
-	    (...)
-
-
-###	graylog_tcp_gelf_servers
-
-A list of one or more remote (or local) server which accept standardized GELF message over HTTP/HTTPS protocol.
-
-This configuration is useful when only HTTP(s) protocol is available accross network boundaries. You can enable TLS (https) to improve confidentiality.
-
-Note that HTTP/TCP introduces coupling between CMT and the remote server. A timeout/maxduration mechanism is used by CMT to limit its global execution time.
+GELF over HTTP(s)/TCP introduces coupling between CMT and the remote server. A timeout/maxduration mechanism is used by CMT to limit its global execution time. HTTP can be  a TLS/SSL URL providing additional security (encryption, endpoint authentication)
 
 See Graylog/GELF documentation for more information.
 
-	# conf.yml
-	graylog_http_gelf_servers:
-	  - name: graylog_test
-	    url: http://10.10.10.13:8080/gelf
-	  - name: graylog_test2
-	    url: http://10.10.10.14:8080/gelf
-	    (...)  
+  graylog_test1:
+      type: graylog_udp_gelf
+      host: 10.10.10.13
+      port: 12201
+  graylog_test2:
+      type: graylog_tcp_gelf
+      url: http://10.10.10.13:8080/gelf
 
-### Teams channel configuration
+      [enable]                : timerange ; default = yes ; master switch
+      ()secret_key
+
+
+### Pager / Teams 
 
 The Microsoft Teams tool uses channels, subscription and notification and  is well suited in the business field, to send and receive alerts and notification.
 
 Each CMT agent can send alerts directly when certain conditions are met.
 
-Two Teams channel may be defined in the configuration : 
-* one for the real Alerts
-* onf for test / heartbeat message.
+Two Teams channel must  be defined in the configuration : 
+* one for the real Alerts  (Channel named *alert*)
+* onf for test / heartbeat message (Channel named *test*)
 
 The Teams URL must be provided for each Channel
 
 
-	# conf.yml
-	teams_channel:
-	   - name: alert
-	     url: https://outlook.office.com/webhook/xxx(...) xxx/IncomingWebhook/yyyy(...)yyy
-	   - name: test
-	     url: https://outlook.office.com/webhook/xxx(...) xxx/IncomingWebhook/yyyy(...)yyy
+	pagers:
+	  alert              : mandatory entry 'alert'
+	     type            : team_channel
+	     url             : https://outlook.office.com/webhook/xx../IncomingWebhook/yyyy...
+	     [enable]        : timerange ; DEFAULT = no ; master switch / no inheritance
+	     ()secret_key    : 
+	     ()add_tags
+	         tag: value
+	         tag: value
+	  test               : mandatory 'test' entry for ARG --pagertest
+	     type            : team_channel
+	     url             : https://outlook.office.com/webhook/xx/IncomingWebhook/yyy...
+	     [enable]        : timerange ; DEFAULT = no  test:
+	     ()secret_key    : 
+	     ()add_tags
+	         tag: value
+	         tag: value
 
-### Teams rate limit
 
-A simple rate-limit for Teams message is implemented in CMT.
+A global pager rate limit is available in the ... global section. A master switch to disable immediately all Pager notification is also available in the global section.
 
-The `teams_rate_limit`configuration defines the minimal number of seconds between any two alerts sent to Teams.
+## Modules
 
-	# conf.yml
-	teams_rate_limit: 3600
+Available moules
 
-## Checks enabled
-
-The second section of the configuration enables the desired checks :
-
-	# conf.yml
-	checks:
+	
+	Modules:
 	  - load
 	  - cpu
 	  - memory
 	  - swap
 	  - boottime
-	  - ntp
 	  - disks
 	  - urls
 	  - mounts
@@ -198,134 +356,241 @@ See the various document (from the sidebar) for each check/module configuration.
 
 
 
-## Example configuration
-
-
-	/dev/cmt_monitor$ more conf.yml
+## Example configuration conf.yml
 	
 	---
 	# Cavaliba / cmt_monitor / conf.yml
+	# V 1.0.0
 
-	# -----------------------------
-	# Global
-	# -----------------------------
+	# Global Section
+	# --------------
 
-	cmt_group: cmtdev
-	cmt_node: vmpio
+	global:
+	  cmt_group: cavaliba
+	  cmt_node: vmxupm
+	  cmt_node_env: dev
+	  cmt_node_role: dev_cmt
+	  cmt_node_location: Ladig
+	  enable: yes
+	  enable_pager: yes
+	  conf_url: http://localhost/cmt/conf/
+	  pager_rate_limit: 3600
+	  max_execution_time: 10
+	  load_confd: yes
+	  alert_max_level: alert
+	  alert_delay: 90
 
-	# -----------------------------
-	# GELF servers for data reports
-	# -----------------------------
-
-	graylog_udp_gelf_servers:
-	  - name: graylog_test
-	    host: 10.10.10.13
-	    port: 12201
-
-	graylog_http_gelf_servers:
-	  - name: graylog_test
-	    url: http://10.10.10.13:8080/gelf
-
-	# ---------------------------
-	# Teams channels for alerts
-	# ---------------------------
-
-	teams_channel:
-	   - name: alert
-	     url: https://outlook.office.com/webhook/xxxxxxx/IncomingWebhook/yyyyyyy
-	   - name: test
-	     url: https://outlook.office.com/webhook/xxxxx/IncomingWebhook/yyyyyyy
-
-	# Rate limit message to Teams to max one every XX seconds
-	teams_rate_limit: 3600
-
+	# Remote metrology servers
 	# ------------------------
-	# Available checks
-	# ------------------------
+	# to store and present data, with alert/warning/notice infos
+
+	metrology_servers:
+	  graylog_test1:
+	      type: graylog_udp_gelf
+	      host: 10.10.10.13
+	      port: 12201
+	      enable: yes
+	  graylog_test2:
+	      type: graylog_http_gelf
+	      url: http://10.10.10.13:8080/gelf
+	      enable: yes
+
+	# Pager services
+	# --------------
+	# to send live alerts to human
+
+	pagers:
+	  alert:
+	    type: team_channel
+	    url: https://outlook.office.com/webhook/xx../IncomingWebhook/yyyy...
+	    enable: yes
+	  test:
+	    type: team_channel
+	    url: https://outlook.office.com/webhook/xx../IncomingWebhook/yyyy...
+	    enable: no
+	     
+	# List of enabled modules
+	# -----------------------
+	modules:
+
+	  load:
+	    enable: yes
+	    alert_max_level: notice
+
+	  cpu:
+	    enable: yes
+
+	  memory:
+	    enable: yes
+
+	  swap:
+	    enable: yes
+
+	  boottime:
+	    enable: yes
+
+	  ntp:
+	    enable: yes
+
+	  disk:
+	    enable: yes
+
+	  url:
+	    enable: yes
+
+	  mount:
+	    enable: yes
+	    alert_max_level: notice    
+
+	  process:
+	    enable: yes
+
+	  ping:
+	    enable: yes
+	    alert_max_level: warn    
+
+	  folder:
+	    enable: yes
+	    #alert_delay: 70
+	    #alert_max_level: alert
+
+
+	# List of checks to perform 
+	# --------------------------
 
 	checks:
-	  - load
-	  - cpu
-	  - memory
-	  - swap
-	  - boottime
-	  - ntp
-	  - disks
-	  - urls
-	  - mounts
-	  - process
-	  - pings
-	  - folders
 
-	# ----------------------------
-	# Parameters for checks
-	# ----------------------------
+	# load
+	  my_load:
+	    module: load
+	    enable: yes
+	    alert_max_level: alert
 
-	disks:
-	  - path: /
-	    alert: 94
+	# cpu
+	  my_cpu:
+	    module: cpu
+	    enable: yes
+	    alert_max_level: alert
 
+	# memory
+	  my_memory:
+	    module: memory
+	    enable: yes
+	    alert_max_level: alert
 
-	urls:
-	  - url: https://www.cavaliba.com/
-	    name: www.cavaliba.com
+	# boottime
+	  boottime:
+	    module: boottime
+	    enable: yes
+	    alert_max_level: alert
+
+	# swap
+	  my_swap:
+	    module: swap
+	    enable: yes
+	    alert_max_level: alert
+
+	# disk  
+	  my_disk_root:
+	    module: disk
+	    path: /
+	    alert: 80
+	  my_disk_boot:
+	    module: disk
+	    path: /boot
+	    alert: 90
+
+	# url
+	  main_website:
+	    module: url
+	    enabled: after 2020-01-01
+	    url: https://www.cavaliba.com/
 	    pattern: "Cavaliba"
 	    allow_redirects: yes
 	    ssl_verify: yes
-	  - url: http://demo.cavaliba.com/
-	    name: demo.cavaliba.com
-	    pattern: "SIRENE"
+	    #host: toto
+	  www_non_existing_for_test:
+	    module: url
+	    enabled: after 2020-01-01
+	    url: http://www.nonexisting/
+	    #pattern: ""
 
 
-	mounts:
-	  - /
-	  - /boot
+	#mount
+	  my_mount_root:
+	    module: mount
+	    path: /
+	  my_mount_mnt:
+	    module: mount
+	    path: /mnt
 
-
-	process:
-	  - name: redis
+	# process
+	  redis:
+	    module: process
 	    psname: redis
-	  - name: apache
+	    enable_pager: no
+	  apache:
+	    module: process
 	    psname: httpd
-	  - name: cron
+	  cron:
+	    module: process
 	    psname: cron
-	  - name: sshd
+	  ssh:
+	    module: process
 	    psname: sshd
-	  - name: ntpd
+	  ntp:
+	    module: process
 	    psname: ntpd
-	  - name: mysqld
+	  mysql:
+	    module: process
 	    psname: mysqld
-	  - name: php-fpm
+	  php-fpm:
+	    module: process
 	    psname: php-fpm
+	    enable_pager: yes
 
-
-	pings:
-	  - 192.168.0.1
-	  - localhost
-	  - 127.0.0.1
-	  - www.cavaliba.com
-
-
-	folders:
-	  - path: /tmp
-	    name: mytmp
+	# ping
+	  ping_vm1:
+	    module: ping
+	    host: 192.168.0.1
+	  ping_locahost:
+	    module: ping
+	    host: localhost
+	  ping_google:
+	    module: ping
+	    host: www.google.com
+	  wwwtest:
+	    module: ping
+	    host: www.test.com    
+	  badname:
+	    module: ping
+	    host: www.averybadnammme_indeed.com  
+	    
+	# folder
+	  folder_mytmp:
+	    module: folder
+	    path: /tmp
+	    alert_max_level: alert
+	    #alert_delay: 30
 	    target:
-	       age_min: 1000
-	       age_max: 300
-	       files_min: 3
-	       files_max: 10
-	       size_min: 100000
-	       size_max: 10
+	       is_blabla:
+	       #age_min: 1000
+	       #age_max: 300
+	       #files_min: 3
+	       #files_max: 10
+	       #size_min: 100000
+	       #size_max: 10
 	       has_files:
-	            - aaa
-	            - bbb
-	  - path: /tmp/absent
-	    name: numbertwo
-	  - path: /tmp/empty
-	    name: number3
+	            - secret.pdf
+	            #- secret2.pdf
+	  folder_number2:
+	    module: folder
+	    path: /missing
 
-	# ------------------------------------
-	# conf.d/*.yml also included with :
-	# - main conf has higher priority
-	# - first level lists merged
-	# ------------------------------------
+
+	# ---------------------------------------------------------
+	# if set global,  conf.d/*.yml also included and merged
+	# ---------------------------------------------------------
+
+
+

--- a/docs/docs/cron.md
+++ b/docs/docs/cron.md
@@ -1,0 +1,37 @@
+---
+title: cron
+---
+
+# CMT used in automatic mode / crontab
+
+
+
+## configure crontab
+
+    $ sudo crontab -e
+
+    * * * * * /usr/local/bin/cmt --conf /opt/cmt/conf.yml --report --pager --persist
+
+## config file: --conf
+
+If not provided, main config file will be searched for in /opt/cmt/conf.yml.
+
+If the python script is used instead of the binay, the conf.yml will be the one next to the cmt.py script.
+
+## option:  --report
+
+Requires CMT to send metrology event to remote server (report to server).
+
+## option:  --pager
+
+Requires CMT to send Pager alert if any.
+
+
+## option:  --persist
+
+Requires CMT to persist some data accross consecutive runs. Not needed in CLI mode.
+
+Some modules (may) use such data to compute delta/derivatives accross runs.
+
+Some alert mechanisms use such data to estimate if an alert is not a transcient event.
+

--- a/docs/docs/data_model.md
+++ b/docs/docs/data_model.md
@@ -1,0 +1,132 @@
+---
+title: Data model
+---
+
+# Data model
+
+This is a quick copy of the data structure available in elasticsearch / kibana.
+
+## Reference
+
+    ===========================================================
+    OUTPUT - REFERENCE
+    ===========================================================
+
+    -------------------------------------------
+    Global Output JSON/GELF
+    -------------------------------------------
+
+    cmt_group         : Customer / Platform ...
+    cmt_node          : VM / instance
+    cmt_node_env      : prod / qa / test / dev ...
+    cmt_node_role     : string - free
+    cmt_node_location : geographical / hosting
+    cmt_module        : module name
+    cmt_check         : module name - deprecated
+    cmt_id            : group.node.module.name
+
+    cmt_alert         : yes/no
+    cmt_warning       : yes/no
+    cmt_notice        : yes/no
+
+    cmt_message       : one line for human / full recap / id. compact mode
+
+
+    specific
+      +cmt_*module*_*
+
+    +GELF mandatory fields
+      source: group_node
+      short_message
+      timestamps
+
+
+    -------------------------------------------
+    Module: load
+    -------------------------------------------
+
+    cmt_load1: #float
+    cmt_load5: #float
+    cmt_load15: #float
+
+    -------------------------------------------
+    Module: cpu
+    -------------------------------------------
+
+    cmt_cpu: #float
+
+    -------------------------------------------
+    Module: memory
+    -------------------------------------------
+
+    cmt_memory_available: #int (bytes)
+    cmt_memory_used: #int (bytes)
+    cmt_memory_percent: #float (percent)
+
+
+    -------------------------------------------
+    Module: swap
+    -------------------------------------------
+
+    cmt_swap_used: #int (bytes)
+    cmt_swap_percent: #float (percent)
+
+    -------------------------------------------
+    Module: boottime
+    -------------------------------------------
+
+    cmt_boottime_days: #int (days)
+    cmt_boottime_seconds: #int (seconds)
+
+    -------------------------------------------
+    Module: mount
+    -------------------------------------------
+
+    cmt_mount            : /path/to/mount
+
+    -------------------------------------------
+    Module: disk
+    -------------------------------------------
+
+    cmt_disk         : /path/to/disk
+    cmt_disk_total   : #int (bytes)
+    cmt_disk_free    : #int (bytes)
+    cmt_disk_percent : #float (percent)  [used]
+
+    -------------------------------------------
+    Module: process
+    -------------------------------------------
+
+    cmt_process_name: string   (config name, not process real name)
+    cmt_process_cpu: float?
+    cmt_process_memory: int (bytes)
+
+    -------------------------------------------
+    Module: url
+    -------------------------------------------
+
+    cmt_url: url string
+    cmt_url_name: url name
+    cmt_url_msec: int        [response time in millisecond if available]
+
+    -------------------------------------------
+    Module: ping
+    -------------------------------------------
+
+    cmt_ping: hostname
+
+    -------------------------------------------
+    Module: folder
+    -------------------------------------------
+    2020/10/07 - v0.7
+    2020/10/20 - v0.9 : + recursive: yes/no
+
+    cmt_folder_name: name
+    cmt_folder_path: path
+    cmt_folder_files: #count
+    cmt_folder_dirs: #count
+    cmt_folder_size: #bytes
+    cmt_folder_size_max: #bytes (folder)
+    cmt_folder_size_min: #bytes (folder)
+    cmt_folder_age_min:
+    cmt_folder_age_max:

--- a/docs/docs/download.md
+++ b/docs/docs/download.md
@@ -12,8 +12,8 @@ title: Download
 ### Version 1.0.0 - 2020/11/29 - Stable
 
 * [Debian 9+ - Ubuntu(s) 16+ - 64bits](http://www.cavaliba.com/download/cmt/cmt-1.0.0-deb64.bin)
-* [Debian 8- 64bits](to be done)
-* [RHEL/Centos 7+ 64 - bits](http://www.cavaliba.com/download/cmt/cmt-1.0.0-centos64.bin)
+* Debian 8- 64bits - to be done
+* RHEL/Centos 7+ 64 - bits - to be done
 
 
 ### Version 0.9 - 2020/09 - Deprecated

--- a/docs/docs/download.md
+++ b/docs/docs/download.md
@@ -12,6 +12,7 @@ title: Download
 ### Version 1.0.0 - 2020/11/29 - Stable
 
 * [Debian 9+ - Ubuntu(s) 16+ - 64bits](http://www.cavaliba.com/download/cmt/cmt-1.0.0-deb64.bin)
+* [Debian 8- 64bits](to be done)
 * [RHEL/Centos 7+ 64 - bits](http://www.cavaliba.com/download/cmt/cmt-1.0.0-centos64.bin)
 
 

--- a/docs/docs/download.md
+++ b/docs/docs/download.md
@@ -9,7 +9,12 @@ title: Download
 
 ## Binary 
 
-### Version 0.9
+### Version 1.0.0 - 2020/11/29 - Stable
 
-* [Debian 9+ / Ubuntu 18+](http://www.cavaliba.com/cmt/download/cmt-v0.9-ubuntu18.bin)
-* [Centos 7](http://www.cavaliba.com/cmt/download/cmt-v0.9-centos7.bin)
+* [Debian 9+ - Ubuntu(s) 16+ - 64bits](http://www.cavaliba.com/download/cmt/cmt-1.0.0-deb64.bin)
+* [RHEL/Centos 7+ 64 - bits](http://www.cavaliba.com/download/cmt/cmt-1.0.0-centos64.bin)
+
+
+### Version 0.9 - 2020/09 - Deprecated
+
+*not available*

--- a/docs/docs/download.md
+++ b/docs/docs/download.md
@@ -12,9 +12,8 @@ title: Download
 ### Version 1.0.0 - 2020/11/29 - Stable
 
 * [Debian 9+ - Ubuntu(s) 16+ - 64bits](http://www.cavaliba.com/download/cmt/cmt-1.0.0-deb64.bin)
+* [RHEL/Centos 7+ - 64 bits](http://www.cavaliba.com/download/cmt/cmt-1.0.0-centos64.bin)
 * Debian 8- 64bits - to be done
-* RHEL/Centos 7+ 64 - bits - to be done
-
 
 ### Version 0.9 - 2020/09 - Deprecated
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -4,57 +4,97 @@ title: Home
 
 # Welcome to CMT Documentation
 
+*Current release : 1.0.0 - 2020/11/29*
 
 ## Overwiew - CMT is a simple monitoring agent
 
-CMT is a small footprint python3 or binary agent thus available for many standard OS. Once deployed on a system, it collects various data and monitors local/remote services. 
+CMT is a small footprint agent, with a single file configuration, available for most standard Linux OS. Once deployed on a system, it collects various data and monitors local/remote services. 
 
 ## Send to ElasticSearch/Graylog
-The collected data are sent to (any) ElasticSearch/Graylog data stores. These data points may carry alert information or warning levels for central alerting or display (Kibana for example).
+
+Collected data is sent to Metrology servers like ElasticSearch/Graylog. These data points may carry alert information or warning levels for central alerting or display (Kibana for example).
 
 ## Alerts and Pager to Teams
+
 If various conditions are met (or not met), CMT can also send direct alerts / pagers notifications to Teams channel.
 
 ## Use as CLI
-You can also use CMT as command line tool on each server during various sysadmin or software configuration tasks.
+
+For sysadmin, CMT can be used as command line tool on each server during various sysadmin or software configuration tasks. One single run provides an immediate health check of all the configured check items.
 
 ## Data model / ElasticStack data storage
-CMT provides a structured data model to improve metrology storage and organization of many monitoring data. You can then build efficent dashborad or data analysis and correlation for reporting, finer alerting, etc.
+
+CMT provides a clean and well organized  data model to enable an efficient metrology storage and further processing of collected data. You can then build various dashborad for data analysis and correlation,  for reporting, finer alerting, etc.
 
 ## Modular
-Ultimately, due to its modular design, it is very easy to add new checks, thus enabling a single tool to cover technical and functionnal monitoring and alerting needs.
+
+Ultimately, due to its simple configuration and modular design, it is very easy to add new checks or new modules, thus enabling a single tool to cover technical and functionnal monitoring and alerting needs.
 
 ## Command and shortcuts
 
 * `cmt --help`
 * (...)
 
+## CMT remote management
+
+CMT optionally supports additional configuration items from a remote URL, downloaded at runtime. It enables various modification from a central server (enable or disable some modules and check, require additional checks, ...). 
+
+No assumption is made on the remote server providing additional configuration. It can be as simple as text files from a shared Web server. It can also be an API to your existing systems which have to respond for a given CMT node, 
+with a slice of configuration to be merged in the node's local configuration.
+
+
+## Modules and Checks
+
+Think of module has class of check for a specific family of items,  like URL, folder, process, disk... Modules are internally implemented as small  python file in the checks/ folder.
+
+Checks are instance of module execution. Each check create one metrology message or event. A check can carry several datapoint (checkitems). Each checks carries optionnal alert,warning, notice information and a message formatted for human reading.
+
+Each Check depending on his Module capacbilities can set information such as alert, warning, notice that will be sent back to metrology servers and possibly direct Pagers services.
+
+Pager notifications are sent only once per CMT exectuion at most. It is intended for (very) standalone usage of CMT, 
+whereas advanced usage with many nodes will benefit from Pager notification fired from central systms where
+decisions can be made from many/all monitoring sources.
+
+CMT provides various configuration to ease configuring alert levels, frequency, rate-limit, max level,  threshold, and other **stop switches** to garantee a clean thread of monitoring data to Metrology servers and Pagers.
+
+
+## CMT automated run from crontab
+
+CMT is intended to run from crontab, every minute. It has a built-in max-duration security to prevent unfinished 
+executing to overcrowd a server.
 
 ## Deployment layout
 
-    /opt/cmt_monitor    # Home dir
-        cmt             # cmt binary agent
-        cmt.py          # or python3 version
-        checks/*.py     # and all modular checks
+    /usr/local/bin/cmt  # binary standalone
+
+    /opt/cmt            # Home dir
+        cmt             # cmt binary agent if prefered over /usr/local/bin
+        cmt*.py         # python3 version
+        checks/*.py     # modular checks
         conf.yml        # configuration what to measure / where to send
         conf.d/         # additional configuration (eg. ansible additive deployment)
-
+        persist.json    # optional data persistance across run
 
 ## Why another monitoring tool ?
 
 The initial requirements were :
 
-* clean metric data structure (multi-tenant, multi-customers, multi nodes)
-* data is sent to very standard ElasticSearch DataStore, private or in the cloud
-* modular design for easy extension / additional cehcks
 * small footprint agent, easy to deploy (drop anywhere ...)
+* clean metric data structure (multi-tenant, multi-customers, multi nodes)
 * simple configuration file (one for all)
-* minimal learning curve
-* covers technical metrics but also functionnal, url, app response, middleware status, ...
-* ansible aware for mass deployement and standization
+* data agnostic: technical, business, ...
+* push rather than pull : push data to metrology servers
+* data is sent to very standard ElasticSearch DataStore, private or in the cloud
+* modular design for easy extension / additional checks or modules
+* minimal learning curve : drop the binary, edit the conf, run as cron/CLI, send to Elasticsearch, create Dashboard.
+* ansible aware for mass deployement and standardization
 * usable as CLI directly on each system
 * open source and hopefully well documented enough
 
-None of the reviewed tools covered this exact set of requirements, some being too specific on some kind of metrics, others requiring a steep learning curve (eg. to extend), other used specific datastore and needed very specific protocol to be allowed (network/firewalls) between agents and datastore ...
+None of the reviewed tools covered this exact set of requirements, some being too specific on technical metrics, others requiring a steep learning curve (eg. to extend), other used specific datastore and needed very specific protocol to be allowed (network/firewalls) between agents and datastore ...
 
+
+## Enjoy
+
+CMT is free to use, free to extend. Experiment, Adopt, Enjoy, contribute.
 

--- a/docs/docs/setup.md
+++ b/docs/docs/setup.md
@@ -1,5 +1,56 @@
 ---
-title: 
+title: setup
 ---
 
-## TODO
+# CMT setup 
+
+## from a binary download
+
+
+    $ curl http://www.cavaliba.com/download/cmt/cmt-XXXXX.bin
+    $ sudo cp cmt-XXXXX.bin /usr/local/bin/cmt
+    $ sudo chmod 755 /usr/local/bin/cmt
+
+
+
+
+## from a github / zip download
+
+* check prerequisite : python3.6+, 
+* unzip to /opt/cmt/
+* install requirements (pyaml, psutils, requests)
+
+    python3 /opt/cmt/cmt.py
+
+
+## Minimal configuration
+
+    $ sudo mkdir /opt/cmt
+    $ sudo vi /opt/cmt/conf.yml
+
+        ---
+
+        # minimal CMT 1.0 configuration
+        # for CLI usage
+
+        global:
+          cmt_group: minidev
+          cmt_node: minihost
+          enable: yes
+
+        #modules:
+        #  load:
+        #    enable: yes
+
+        checks:
+          my_load:
+            module: load
+
+
+
+## Next
+
+* use CLI mode to configure
+* use --available option to identify items to monnitor
+* configure crontab
+* watch for event in your elastic/graylog/kibana server

--- a/docs/docs/stylesheets/extra.css
+++ b/docs/docs/stylesheets/extra.css
@@ -1,0 +1,25 @@
+
+.md-typeset code {
+    padding: 0 .2941176471em;
+    font-size: .75em;
+    word-break: break-word;
+    background-color: var(--md-code-bg-color);
+    border-radius: .1rem;
+    -webkit-box-decoration-break: clone;
+    box-decoration-break: clone;
+}
+
+.md-nav {
+    font-size: .6rem;
+    line-height: 1.3;
+}
+
+.md-sidebar {
+    position: -webkit-sticky;
+    position: sticky;
+    top: 2.4rem;
+    align-self: flex-start;
+    width: 12.1rem;
+    height: 0;
+    padding: 1.2rem 0;
+}

--- a/docs/docs/version.md
+++ b/docs/docs/version.md
@@ -1,0 +1,134 @@
+---
+title: version
+---
+
+# Versions and Releases
+
+
+## Next / Roadmap
+
+    x module : socket
+    x module : ssl certificate
+
+
+## 1.0.0 - 2020/11/29
+
+    x conf : conf.d on/off : global load_confd yes/no
+    x remote conf : send group.node as parameters (or as file.txt )  
+    x ARG : --debug2
+    x ARG : --no-pager-rate-limit
+    x ARG : --persist
+    x give persist to modules
+    x default homedir = /opt/cmt
+    x conf: enable_pager for check
+    x Pager events contain all alert/warn/notice messages
+    x hysteresis up (alert_delay in global/module/check)
+    x cmt_node_env [prod,form, pre,qual, test, dev]
+    x cmt_node_role: string
+    x cmt_node_location
+    x Pattern optionnal in module URL
+    x removed module_*_status checkItems (not needed any more ; use alert/warning/notice)
+    x module url : add "host" option (virtualhost header)
+
+## 1.0.0.RC
+
+    x new alert/warn/notice ; simplified ChecKItems
+    x class Persist()
+    x Secu : injection de config/parametres dans appels shell ; subprocess
+    x max execution time in conf
+    x remote conf : http://host/conf/..../  (+group_node.txt if trailing /) 
+    x level alert/warn/notice by framework
+
+
+## 1.0.0.beta
+
+    x  major redesign - new config with dict ; no uuid ; single MAP
+
+## 1.0.0.alpha - Breaking changes
+
+    x new modules structure in config ; checks deprecated
+    x timerange + enable option in global/modules/check
+    x ARG : --devmode
+    x conf: global send_to_pager (timerange, default = no)
+    x conf: teams channel : enable 
+    x global : field: cmt_message ; compact status
+    x cli: compact display ; status only ;   ARG : compact display option (--status)
+    x uuid/id in conf and events ; uuid = group.node.module.id ; id = check specific value
+    x check objet given to (not created by) each Chech module
+    x config merge more clever !
+    x conf_url option : remote config to be fetched and  merged into main/additional configs
+
+
+
+## old
+
+## 0.9
+    x (0.9) bug : binary version find local conf.yml
+    x (0.9) feature : recursive folder check option (recursive: yes/no)
+    x (0.9) Documentation MkDocs (framzwork)
+    x => 2020-10-25 - PUSH GITHUB v0.9
+
+## 0.8
+    x (0.8) refactor : split checks in separate files (2020/10/20)
+
+## 0.7
+
+    x (0.7) accept missing check entries in configuration (urls, disks, ...) : MODULE_LIST
+    x (0.7) checks : folders
+    x test pyinstaller (0.7 : 10 MB)
+
+## 0.6
+
+    x (0.6) abort if missing config file
+    x (0.6) abort if missing item 'checks' in config file
+    x (0.6) accept missing conf.d
+    x (0.6) accept missing graylog_servers_* entries in config
+    x (0.6) timeout when sending http/gelf to graylog + suspended if previous errors
+    x (0.6) timeout when sending to Teams
+    x (0.6) conf option : --conf filename
+
+## 0.5
+
+    x (0.5) check_url : requests : verify = False, allow_redirects = False
+    x (0.5) check_url : requests : requests.packages.urllib3.disable_warnings()
+    x (0.5) check_url : with response time  cmt_url_msec (int)
+    x (0.5) check_url : verify options for each URL
+    x (0.5) option : available (process, mounts)
+    x (0.5) check_mounts : with available option
+    x (0.5) check_pings
+
+## 0.4
+
+    x (0.4) check_process
+
+
+
+    x conf YAML
+    x cli / argparse
+    x send data to graylog
+    x send alerts to Teams
+    x option --report
+    x option --alert
+    x log with timestamp  (for cron.log)
+    x alert vs global_alert
+    x name group/node
+    x gitlab,  README.md, conf.yml.ori
+    x find conf.yml basedir > commit V 0.1
+    x requirements.txt : pyyaml, requests, psutil
+    x config multi-file for  ansible
+    x get_config_or_default()
+    x debug() option and function
+    x output to gelf over http
+    x added cmt_check/cmt_node/cmt_group fields
+    x teams alerts rate limited in configuration
+    x error if empty list in conf (merge + checks)
+    x logs : /var/log/cmt/cmt.log + logrotate (ansible)
+    x FullLoader > SafeLoader
+    x send alert for URL failed
+    x ansible role centos 7, centos 8
+    x option --list-modules
+    x cli print version
+    x cli print available modules
+    x nicer cli print format with  units (MB, GB, % ...)
+
+

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,19 +1,24 @@
 site_name: CMT Monitor Documentation
 copyright: 2020 - cavaliba.com
 
-theme: 
+theme:
   name: material
   font: false
   language: en
+
+extra_css:
+  - stylesheets/extra.css
 
 nav:
   - 'Home': 'index.md'
 #  - 'Quickstart': 'quickstart.md'
   - 'Download': 'download.md'
-#  - 'Setup': 'setup.md'
+  - 'Setup': 'setup.md'
   - 'Configuration': 'config.md'
 #  - 'Datastore / ElasticStack': 'server.md'
 #  - 'FAQ': 'faq.md'
+  - 'CLI': 'cli.md'
+  - 'Cron / Automatic run' : 'cron.md'
   - 'Checks': 
       - 'load': 'check_load.md'
       - 'cpu': 'check_cpu.md'
@@ -26,10 +31,11 @@ nav:
       - 'urls': 'check_urls.md'
       - 'folders': 'check_folders.md'
       - 'pings': 'check_pings.md'
+  - 'Data model' : 'data_model.md'
 #  - 'Dev / How to extend': 'extend.md'
   - 'License': license.md
   - 'Visit cavaliba.com': 'http://www.cavaliba.com'
-#- revision / versions
+  - 'Versions': 'version.md'
 #- upgrade
 #- full configuration
 #- ansible

--- a/helpers.py
+++ b/helpers.py
@@ -4,8 +4,8 @@ import datetime
 def parse_duration(string):
     """parse something like "1 day 2 hours".
 
-    Units can be singular or plural. Supported units are days, months, weeks and hours. A
-    months is equivalent to 30 days.
+    Units can be singular or plural. Supported units are years, months, weeks, days and
+    hours. A months is equivalent to 30 days. A year is 365 days.
 
     Negatives values aren't supported.
     """
@@ -22,7 +22,11 @@ def parse_duration(string):
                 quantifier = int(word)
             except ValueError:
                 # for better context (both exceptions will be printed though)
-                raise ValueError("Failed parsing duration {!r}".format(string))
+                raise ValueError(
+                    "failed parsing quantifier {!r} in duration {!r}".format(
+                        word, string
+                    )
+                )
 
             if quantifier < 0:
                 raise ValueError("don't use negative values {!r}".format(string))
@@ -32,7 +36,7 @@ def parse_duration(string):
             if not word.endswith("s"):
                 word += "s"
 
-            if word not in ("weeks", "days", "months", "hours"):
+            if word not in ("years", "weeks", "days", "months", "hours"):
                 raise ValueError("invalid unit {!r} in {!r}".format(word, string))
 
             if word in kwargs:
@@ -49,10 +53,15 @@ def parse_duration(string):
             )
         )
 
-    # dealing with the variations in the number of days of each months would be an
+    # dealing with the variations in the number of days of each months/year would be an
     # overkill here
+
     if "months" in kwargs:
         kwargs["days"] = kwargs.get("days", 0) + 30 * kwargs["months"]
         del kwargs["months"]
+
+    if "years" in kwargs:
+        kwargs["days"] = kwargs.get("days", 0) + 365 * kwargs["years"]
+        del kwargs["years"]
 
     return datetime.timedelta(**kwargs)

--- a/helpers.py
+++ b/helpers.py
@@ -1,0 +1,58 @@
+import datetime
+
+
+def parse_duration(string):
+    """parse something like "1 day 2 hours".
+
+    Units can be singular or plural. Supported units are days, months, weeks and hours. A
+    months is equivalent to 30 days.
+
+    Negatives values aren't supported.
+    """
+
+    if string.strip() == "":
+        raise ValueError("duration cannot be just empty space {!r}", string)
+
+    words = string.split(" ")
+    kwargs = {}
+    quantifier = None
+    for i, word in enumerate(words):
+        if i % 2 == 0:
+            try:
+                quantifier = int(word)
+            except ValueError:
+                # for better context (both exceptions will be printed though)
+                raise ValueError("Failed parsing duration {!r}".format(string))
+
+            if quantifier < 0:
+                raise ValueError("don't use negative values {!r}".format(string))
+
+        else:
+            # it's a unit
+            if not word.endswith("s"):
+                word += "s"
+
+            if word not in ("weeks", "days", "months", "hours"):
+                raise ValueError("invalid unit {!r} in {!r}".format(word, string))
+
+            if word in kwargs:
+                raise ValueError("unit {!r} already used in {!r}".format(word, string))
+
+            kwargs[word] = quantifier
+
+            quantifier = None
+
+    if quantifier is not None:
+        raise ValueError(
+            "unit expected for the last quantifier {!r} in {!r}".format(
+                quantifier, string
+            )
+        )
+
+    # dealing with the variations in the number of days of each months would be an
+    # overkill here
+    if "months" in kwargs:
+        kwargs["days"] = kwargs.get("days", 0) + 30 * kwargs["months"]
+        del kwargs["months"]
+
+    return datetime.timedelta(**kwargs)

--- a/tests/test_parse_duration.py
+++ b/tests/test_parse_duration.py
@@ -1,0 +1,64 @@
+import pytest
+import datetime
+
+from helpers import parse_duration
+
+
+def test_examples():
+    assert parse_duration("1 week 2 days") == datetime.timedelta(days=7 + 2)
+    assert parse_duration("1 month 2 weeks") == datetime.timedelta(days=30 + 2 * 7)
+    assert parse_duration("12 hours") == datetime.timedelta(hours=12)
+
+    assert parse_duration("1 hour 8 days") == datetime.timedelta(hours=1, days=8)
+    assert parse_duration("1 hours 8 days") == datetime.timedelta(hours=1, days=8)
+
+    with pytest.raises(ValueError):
+        parse_duration("1 hour 2 hour")
+
+    with pytest.raises(ValueError):
+        parse_duration("1 invalidunit")
+
+    with pytest.raises(ValueError):
+        parse_duration("1 invalidunits")
+
+    with pytest.raises(ValueError):
+        parse_duration("hour 2")
+
+    with pytest.raises(ValueError):
+        parse_duration("2hours")
+
+    with pytest.raises(ValueError):
+        parse_duration("2 hours 3")
+
+    with pytest.raises(ValueError):
+        parse_duration("-2 hours")
+
+    assert parse_duration("24 hours") == parse_duration("1 day")
+
+
+def test_simple_durations():
+    assert parse_duration("1 month") == datetime.timedelta(days=30)
+    assert parse_duration("2 month") == datetime.timedelta(days=2 * 30)
+    assert parse_duration("1 months") == datetime.timedelta(days=30)
+    assert parse_duration("2 months") == datetime.timedelta(days=2 * 30)
+
+    assert parse_duration("1 week") == datetime.timedelta(days=7)
+    assert parse_duration("2 week") == datetime.timedelta(days=14)
+    assert parse_duration("1 weeks") == datetime.timedelta(days=7)
+    assert parse_duration("2 weeks") == datetime.timedelta(days=14)
+
+    assert parse_duration("1 hour") == datetime.timedelta(hours=1)
+    assert parse_duration("2 hour") == datetime.timedelta(hours=2)
+    assert parse_duration("1 hours") == datetime.timedelta(hours=1)
+    assert parse_duration("2 hours") == datetime.timedelta(hours=2)
+
+    assert parse_duration("1 day") == datetime.timedelta(days=1)
+    assert parse_duration("2 day") == datetime.timedelta(days=2)
+    assert parse_duration("1 days") == datetime.timedelta(days=1)
+    assert parse_duration("2 days") == datetime.timedelta(days=2)
+
+
+def test_composite():
+    assert parse_duration("3 month 78 weeks 12 days 314 hours") == datetime.timedelta(
+        days=3 * 30 + 78 * 7 + 12, hours=314
+    )

--- a/tests/test_parse_duration.py
+++ b/tests/test_parse_duration.py
@@ -57,8 +57,13 @@ def test_simple_durations():
     assert parse_duration("1 days") == datetime.timedelta(days=1)
     assert parse_duration("2 days") == datetime.timedelta(days=2)
 
+    assert parse_duration("1 year") == datetime.timedelta(days=1 * 365)
+    assert parse_duration("2 year") == datetime.timedelta(days=2 * 365)
+    assert parse_duration("1 years") == datetime.timedelta(days=1 * 365)
+    assert parse_duration("2 years") == datetime.timedelta(days=2 * 365)
+
 
 def test_composite():
-    assert parse_duration("3 month 78 weeks 12 days 314 hours") == datetime.timedelta(
-        days=3 * 30 + 78 * 7 + 12, hours=314
+    assert parse_duration("27 years 3 month 78 weeks 12 days 314 hours") == datetime.timedelta(
+        days=27 * 365 + 3 * 30 + 78 * 7 + 12, hours=314
     )


### PR DESCRIPTION
There is tls in the branch name, but it's uses the SSL python module, which does both SSL and TLS. Not sure how people thought using SSL to mean TLS was a good idea in the first place.

The function names are free of TLS/SSL.

---

```yaml
---

global:
  cmt_group: dev
  cmt_node: dev
  enable: yes

checks:
  google:
    module: certificate
    hostname: google.com
    alert_expires_in: 6 months 3 days

  duck:
    module: certificate
    hostname: duckduckgo.com
    alert_expires_in: 1 week
```

```
$ python cmt.py certificate
------------------------------------------------------------
CMT - Version 1.0.0 - (c) Cavaliba.com - 2020/11/29
------------------------------------------------------------
2020/12/05 - 18:39:28 : Starting ...
cmt_group      :  dev
cmt_node       :  dev


Check certificate
cmt_certificate_hostname google.com  ()  - Hostname
cmt_certificate_port   443  ()  - Port
cmt_certificate_expires_in 4492454 seconds (51 days, 23:54:14)
cmt_certificate_issuer_common_name GTS CA 1O1  ()
cmt_certificate_issuer_organization_name Google Trust Services  ()
cmt_certificate_subject_common_name *.google.com  ()
cmt_certificate_subject_organization_name Google LLC  ()
NOK                    hostname: google.com:443 - certificate will expire soon (in 51 days, 23:54:13.692354)

Check certificate
cmt_certificate_hostname duckduckgo.com  ()  - Hostname
cmt_certificate_port   443  ()  - Port
cmt_certificate_expires_in 29348432 seconds (339 days, 16:20:32)
cmt_certificate_issuer_common_name DigiCert SHA2 Secure Server CA  ()
cmt_certificate_issuer_organization_name DigiCert Inc  ()
cmt_certificate_subject_common_name *.duckduckgo.com  ()
cmt_certificate_subject_organization_name Duck Duck Go, Inc.  ()
OK

Notification Summary
--------------------

No notice

No warnings

Alerts
certificate     : hostname: google.com:443 - certificate will expire soon (in 51 days, 23:54:13.692354)

2020/12/05 - 18:39:28 : Done.
```

---

All the information is retrieved from `ssock.getpeercert()` which returns a [pretty messy data structure](https://tools.ietf.org/html/rfc3280.html#section-4.1.2.4). 

`cmt.py`, `cmt_global.py` and `cmt_shared.py` have a lot of meaningless diff: just some white spaces my editor stripped automatically.

To run the tests (first, make sure to `pip install pytest`):

```bash
~/code/cavaliba/cmt_monitor $ python -m pytest
```

I didn't put the function `parse_duration` in `cmt_shared` because it caused a circular import loop when running the tests. A better file structure should be used.

<details>
<summary>circular import</summary>

```
Traceback:                                                                                                                                                                                                 
/usr/lib/python3.8/importlib/__init__.py:127: in import_module                                                                                                                                             
    return _bootstrap._gcd_import(name[level:], package, level)                                                                                                                                            
tests/test_parse_duration.py:5: in <module>                                                                                                                                                                
    from cmt_shared import parse_duration                                                                                                                                                                  
cmt_shared.py:18: in <module>                                                                                                                                                                              
    import cmt_globals as cmt                                                                                                                                                                              
cmt_globals.py:10: in <module>                                                                                                                                                                             
    from checks.load import check_load                                                                                                                                                                     
checks/load.py:5: in <module>                                                                                                                                                                              
    from cmt_shared import Check, CheckItem                                                                                                                                                                
E   ImportError: cannot import name 'Check' from partially initialized module 'cmt_shared' (most likely due to a circular import) (/home/math2001/code/cavaliba/cmt_monitor/cmt_shared.py) 
```

</details>