### PR TITLE
certificates module

### DIFF
--- a/checks/certificate.py
+++ b/checks/certificate.py
@@ -2,7 +2,9 @@ import sys
 import ssl
 import socket
 import datetime
-from cmt_shared import Check, CheckItem, parse_duration
+
+from cmt_shared import Check, CheckItem
+from helpers import parse_duration
 
 
 def check_certificate(c):

--- a/checks/certificate.py
+++ b/checks/certificate.py
@@ -1,0 +1,113 @@
+import sys
+import ssl
+import socket
+import datetime
+from cmt_shared import Check, CheckItem, parse_duration
+
+
+def check_certificate(c):
+
+    assert sys.version_info >= (3, 5), "Python interpreter is too old"
+
+    # get every settings at the start so that we don't crash mid-check if a key
+    # is missing
+    hostname = c.conf["hostname"]
+    threshold = parse_duration(c.conf["alert_expires_in"])
+    port = c.conf.get("port", 443)
+
+    c.add_item(CheckItem("certificate_hostname", hostname, "Hostname"))
+    c.add_item(CheckItem("certificate_port", port, "Port"))
+
+    cert_infos = get_certificate_infos(hostname, port)
+
+    # certificate dates are in utc. Just reading the warning from the documentation,
+    # it seems like Python's datetime modules is pretty bad when it comes to managing
+    # timezones correctly. So, keep everything in terms of UTC.
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    if now > cert_infos["notAfter"]:
+        c.alert += 1
+        c.add_message(
+            "hostname: {}:{} - certifcate expired by {}".format(
+                hostname, port, now - cert_infos["notAfter"]
+            )
+        )
+    elif now < cert_infos["notBefore"]:
+        c.alert += 1
+        c.add_message(
+            "hostname: {}:{} - certifcate not yet valid (will be valid in {})".format(
+                hostname, port, cert_infos["notBefore"] - now
+            )
+        )
+
+    expires_in = cert_infos["notAfter"] - now
+    if expires_in < threshold:
+        c.alert += 1
+        c.add_message(
+            "hostname: {}:{} - certificate will expire soon (in {})".format(
+                hostname, port, expires_in
+            )
+        )
+
+    c.add_item(
+        CheckItem(
+            "certificate_expires_in",
+            int(round(expires_in.total_seconds())),
+            unit="seconds",
+        )
+    )
+    c.add_item(
+        CheckItem("certificate_issuer_common_name", cert_infos["issuer"]["commonName"])
+    )
+    c.add_item(
+        CheckItem(
+            "certificate_issuer_organization_name",
+            cert_infos["issuer"]["organizationName"],
+        )
+    )
+    c.add_item(
+        CheckItem(
+            "certificate_subject_common_name", cert_infos["subject"]["commonName"]
+        )
+    )
+    c.add_item(
+        CheckItem(
+            "certificate_subject_organization_name",
+            cert_infos["subject"]["organizationName"],
+        )
+    )
+
+    return c
+
+
+def get_certificate_infos(hostname, port):
+    context = ssl.create_default_context()
+
+    with socket.create_connection((hostname, 443)) as sock:
+        with context.wrap_socket(sock, server_hostname=hostname) as ssock:
+            cert = ssock.getpeercert()
+
+    if cert is None:
+        raise ValueError(f"no certificate found ({cert})")
+
+    todatetime = lambda x: datetime.datetime.fromtimestamp(
+        ssl.cert_time_to_seconds(x), tz=datetime.timezone.utc
+    )
+    return {
+        "notAfter": todatetime(cert["notAfter"]),
+        "notBefore": todatetime(cert["notBefore"]),
+        "issuer": get_source_infos(cert["issuer"]),
+        "subject": get_source_infos(cert["subject"]),
+    }
+
+
+def get_source_infos(rdns):
+    infos = {}
+    for rdn in rdns:
+        for key, value in rdn:
+            if key in ("organizationName", "commonName"):
+                infos[key] = value
+
+    return {
+        "organizationName": infos.get("organizationName", "<no organization name>"),
+        "commonName": infos.get("commonName", "<no common name>"),
+    }

--- a/checks/certificate.py
+++ b/checks/certificate.py
@@ -15,6 +15,7 @@ def check_certificate(c):
     # get every settings at the start so that we don't crash mid-check if a key
     # is missing
     hostname = c.conf["hostname"]
+    # should there be a default value?
     threshold = parse_duration(c.conf["alert_expires_in"])
     port = c.conf.get("port", 443)
 

--- a/checks/certificate.py
+++ b/checks/certificate.py
@@ -6,7 +6,8 @@ from cmt_shared import Check, CheckItem, parse_duration
 
 
 def check_certificate(c):
-
+    # if this assertion fails, then we have to be even more careful of timezones.
+    # ref ssl.cert_time_to_seconds
     assert sys.version_info >= (3, 5), "Python interpreter is too old"
 
     # get every settings at the start so that we don't crash mid-check if a key
@@ -27,14 +28,14 @@ def check_certificate(c):
     if now > cert_infos["notAfter"]:
         c.alert += 1
         c.add_message(
-            "hostname: {}:{} - certifcate expired by {}".format(
+            "hostname: {}:{} - certificate expired by {}".format(
                 hostname, port, now - cert_infos["notAfter"]
             )
         )
     elif now < cert_infos["notBefore"]:
         c.alert += 1
         c.add_message(
-            "hostname: {}:{} - certifcate not yet valid (will be valid in {})".format(
+            "hostname: {}:{} - certificate not yet valid (will be valid in {})".format(
                 hostname, port, cert_infos["notBefore"] - now
             )
         )

--- a/cmt.py
+++ b/cmt.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python3
-# cavaliba.com - 2020 - CMT_monitor - cmt.py 
-
+# cavaliba.com - 2020 - CMT_monitor - cmt.py
 
 import os
 import sys
@@ -14,8 +13,6 @@ import requests
 
 # global variables
 import cmt_globals as cmt
-
-
 
 # shared functions and class
 from cmt_shared import logit, debug, abort, bcolors
@@ -45,8 +42,8 @@ def signal_handler(signum, frame):
 if __name__=="__main__":
 
 
-    
-    cmt.ARGS = parse_arguments()    
+
+    cmt.ARGS = parse_arguments()
 
     if cmt.ARGS["version"]:
         display_version()
@@ -141,7 +138,7 @@ if __name__=="__main__":
         # no info
         if ts_check == "n/a":
             # module level ?
-            if not is_module_active_in_conf(modulename):  
+            if not is_module_active_in_conf(modulename):
                 debug("  module disabled in conf")
                 continue #no
         elif not is_timeswitch_on(ts_check):
@@ -184,16 +181,16 @@ if __name__=="__main__":
         # keep returned Persist structure in check_result
         cmt.PERSIST.set_key(check_result.get_id(), check_result.persist)
 
-        
+
         if cmt.ARGS['short']:
             check_result.print_to_cli_short()
         else:
             check_result.print_to_cli_detail()
-        
-        if cmt.ARGS["report"]:            
+
+        if cmt.ARGS["report"]:
             check_result.send_metrology()
 
-        
+
         # add Check to report
         report.add_check(check_result)
 

--- a/cmt_globals.py
+++ b/cmt_globals.py
@@ -1,4 +1,4 @@
-# cavaliba.com - 2020 - CMT_monitor - cmt.py 
+# cavaliba.com - 2020 - CMT_monitor - cmt.py
 
 # cmt_globals
 
@@ -18,6 +18,7 @@ from checks.url import check_url
 from checks.process import check_process
 from checks.ping import check_ping
 from checks.folder import check_folder
+from checks.certificate import check_certificate
 
 
 requests.packages.urllib3.disable_warnings()
@@ -40,7 +41,7 @@ elif __file__:
 
 #RATE_LIMIT_FILE = os.path.join(HOME_DIR, "alert.last")
 
-GRAYLOG_HTTP_TIMEOUT = 5 
+GRAYLOG_HTTP_TIMEOUT = 5
 
 # http access to remote url for additional config
 REMOTE_CONFIG_TIMEOUT = 3
@@ -57,7 +58,7 @@ DEFAULT_HYSTERESIS_NORMAL_DELAY = 120
 # persist
 DEFAULT_PERSIST_FILE = os.path.join(HOME_DIR, "persist.json")
 
-# Used to load / merge config 
+# Used to load / merge config
 DEFAULT_CONF_TOP_ENTRIES = ['global','modules','checks','metrology_servers', 'pagers']
 
 # =====================================================================
@@ -65,17 +66,18 @@ DEFAULT_CONF_TOP_ENTRIES = ['global','modules','checks','metrology_servers', 'pa
 # =====================================================================
 
 GLOBAL_MODULE_MAP = {
-    "load"     : {"check": check_load     },
-    "cpu"      : {"check": check_cpu      },
-    "memory"   : {"check": check_memory   },
-    "swap"     : {"check": check_swap     },
-    "boottime" : {"check": check_boottime },
-    "mount"    : {"check": check_mount    },
-    "disk"     : {"check": check_disk     },
-    "url"      : {"check": check_url      },
-    "process"  : {"check": check_process  },
-    "ping"     : {"check": check_ping     },
-    "folder"   : {"check": check_folder   },
+    "load"       : {"check": check_load        },
+    "cpu"        : {"check": check_cpu         },
+    "memory"     : {"check": check_memory      },
+    "swap"       : {"check": check_swap        },
+    "boottime"   : {"check": check_boottime    },
+    "mount"      : {"check": check_mount       },
+    "disk"       : {"check": check_disk        },
+    "url"        : {"check": check_url         },
+    "process"    : {"check": check_process     },
+    "ping"       : {"check": check_ping        },
+    "folder"     : {"check": check_folder      },
+    "certificate": {"check": check_certificate }
 }
 
 

--- a/cmt_shared.py
+++ b/cmt_shared.py
@@ -1,4 +1,4 @@
-# cavaliba.com - 2020 - CMT_monitor - cmt.py 
+# cavaliba.com - 2020 - CMT_monitor - cmt.py
 # cmt_shared.py
 #    - common functions, class and structures
 
@@ -16,7 +16,7 @@ import requests
 requests.packages.urllib3.disable_warnings()
 
 import cmt_globals as cmt
-from cmt_globals import *
+# from cmt_globals import *
 
 
 # ----------------------------------------------------------
@@ -75,10 +75,10 @@ def is_timeswitch_on(myconfig):
 
     if myconfig == "False" or myconfig =="no"  or myconfig == "false":
         return False
-    
+
     myarray = myconfig.split()
     action = myarray.pop(0)
-    
+
     if action  == "after":
         mynow = datetime.datetime.today().strftime("%Y-%m-%d %H:%M:%S")
         target = ' '.join(myarray)
@@ -120,6 +120,7 @@ def is_timeswitch_on(myconfig):
     # default, unknown / no match
     return False
 
+
 # -----------------------------------------------------
 # short commands
 # -----------------------------------------------------
@@ -134,7 +135,7 @@ def display_modules():
 
     for key in cmt.GLOBAL_MODULE_MAP:
         print("  - ", key )
-    
+
 
 # ----------------------------------------------------------
 # Args on CLI
@@ -144,45 +145,45 @@ def parse_arguments():
     parser = argparse.ArgumentParser(description='CMT - Cavaliba Monitoring')
 
     #parser.add_argument('--conf', dest="config_file", type=str ,help="configuration file")
-    
-    parser.add_argument('--report', help='send events to Metrology servers', 
+
+    parser.add_argument('--report', help='send events to Metrology servers',
         action='store_true', required=False)
-    parser.add_argument('--pager', help='send alerts to Pagers', 
+    parser.add_argument('--pager', help='send alerts to Pagers',
         action='store_true', required=False)
     parser.add_argument('--persist', help='persist data accross CMT runs (use in cron)',
         action='store_true', required=False)
 
-    parser.add_argument('--conf', help='specify alternate yaml config file', 
+    parser.add_argument('--conf', help='specify alternate yaml config file',
         action='store', required=False)
 
-    parser.add_argument('modules', nargs='*',  
+    parser.add_argument('modules', nargs='*',
         action='append', help='modules to check')
-    
-    parser.add_argument('--pagertest', help='send test message to teams and exit', 
+
+    parser.add_argument('--pagertest', help='send test message to teams and exit',
         action='store_true', required=False)
-    parser.add_argument('--no-pager-rate-limit', help='disable pager rate limit', 
-        action='store_true', required=False)  
+    parser.add_argument('--no-pager-rate-limit', help='disable pager rate limit',
+        action='store_true', required=False)
 
 
-    parser.add_argument('--checkconfig', help='checkconfig and exit', 
+    parser.add_argument('--checkconfig', help='checkconfig and exit',
         action='store_true', required=False)
 
-    parser.add_argument('--version', '-v', help='display current version', 
+    parser.add_argument('--version', '-v', help='display current version',
         action='store_true', required=False)
-    parser.add_argument('--debug', help='verbose/debug output', 
+    parser.add_argument('--debug', help='verbose/debug output',
         action='store_true', required=False)
-    parser.add_argument('--debug2', help='more debug', 
+    parser.add_argument('--debug2', help='more debug',
         action='store_true', required=False)
 
-    parser.add_argument('--short','-s', help='short compact cli output', 
+    parser.add_argument('--short','-s', help='short compact cli output',
         action='store_true', required=False)
-    parser.add_argument('--devmode', help='dev mode, no pager, no remote metrology', 
-        action='store_true', required=False)    
+    parser.add_argument('--devmode', help='dev mode, no pager, no remote metrology',
+        action='store_true', required=False)
 
 
-    parser.add_argument('--listmodules', help='display available modules', 
+    parser.add_argument('--listmodules', help='display available modules',
         action='store_true', required=False)
-    parser.add_argument('--available', help='display available entries found for modules (manual run on target)', 
+    parser.add_argument('--available', help='display available entries found for modules (manual run on target)',
         action='store_true', required=False)
 
 
@@ -200,7 +201,7 @@ def load_conf():
     conf = conf_add_default_modules(conf)
     conf = load_conf_dirs(conf)
     conf = load_conf_remote(conf)
-    
+
     return conf
 
 
@@ -209,11 +210,11 @@ def load_conf_master():
 
     debug("Load master conf")
 
-    if cmt.ARGS['conf']: 
-        config_file = cmt.ARGS['conf']    
-    else:        
-        config_file = os.path.join(cmt.HOME_DIR, "conf.yml")    
-    
+    if cmt.ARGS['conf']:
+        config_file = cmt.ARGS['conf']
+    else:
+        config_file = os.path.join(cmt.HOME_DIR, "conf.yml")
+
     debug("Config file : ", config_file)
 
     if not os.path.exists(config_file):
@@ -260,14 +261,14 @@ def load_conf_dirs(conf):
 def load_conf_remote(conf):
 
     debug("Load remote conf")
-    
+
     # load remote config from conf_url parameter
     if 'conf_url' in conf['global']:
-                
+
         url = conf['global']['conf_url']
         gro = conf['global'].get("cmt_group","nogroup")
         nod = conf['global'].get("cmt_node","nonode")
-    
+
         if url[-1] == '/':
             url = url + "{}_{}.txt".format(gro,nod)
 
@@ -292,7 +293,7 @@ def conf_add_default_modules(conf):
     for key in cmt.GLOBAL_MODULE_MAP:
         #print("  - ", key )
         if key not in conf['modules']:
-            conf['modules'][key] = {}            
+            conf['modules'][key] = {}
     return conf
 
 # -----------
@@ -309,13 +310,13 @@ def conf_add_top_entries(conf):
 # -----------
 # load a single file
 def conf_load_file(config_file):
-    
+
     with open(config_file) as f:
         conf = yaml.load(f, Loader=yaml.SafeLoader)
         #print(CONF)
         #print(json.dumps(CONF, indent=2))
 
-    # # verify content  
+    # # verify content
     if conf is None:
         return {}
     #    abort("Bad config; Exiting.")
@@ -372,16 +373,16 @@ def is_module_active_in_conf(module):
         return True
 
     timerange = cmt.CONF['modules'][module].get("enable", "yes")
-    
+
     if is_timeswitch_on(timerange):
         return True
-    
+
     debug("module not enabled in conf : ", module)
     return False
 
 
 def conf_get_hysteresis(check):
-    ''' return configuration for alert_delay, resume_delay 
+    ''' return configuration for alert_delay, resume_delay
         with inheritance: check, module, global, DEFAULT.
     '''
 
@@ -455,7 +456,7 @@ def pager_test():
 
 
 # ------------------------------------------------------------
-# Metrology Servers 
+# Metrology Servers
 # ------------------------------------------------------------
 
 
@@ -465,7 +466,7 @@ def pager_test():
 def build_gelf_message(check):
     '''Prepare a GELF JSON message suitable to be sent to a Graylog GELF server.'''
 
-    graylog_data = '"version":"1.1",' 
+    graylog_data = '"version":"1.1",'
     graylog_data += '"host":"{}_{}",'.format(check.group, check.node)
 
     # common values
@@ -515,13 +516,13 @@ def build_gelf_message(check):
 
 
     graylog_data = '{' + graylog_data + '}'
-    
+
     return graylog_data
 
 
 
 def graylog_send_http_gelf(url, data=""):
-    
+
     headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
 
     if cmt.GRAYLOG_HTTP_SUSPENDED:
@@ -533,7 +534,7 @@ def graylog_send_http_gelf(url, data=""):
         return
 
     try:
-        r = cmt.SESSION.post(url, data=data, headers=headers, timeout = cmt.GRAYLOG_HTTP_TIMEOUT)    
+        r = cmt.SESSION.post(url, data=data, headers=headers, timeout = cmt.GRAYLOG_HTTP_TIMEOUT)
         debug("Message sent to graylog(http/gelf) ; status = " + str(r.status_code))
     except:
         logit("Error - couldn't send graylog message (http/gelf) to " + str(url))
@@ -543,7 +544,7 @@ def graylog_send_http_gelf(url, data=""):
 def graylog_send_udp_gelf(host, port=12201, data=""):
 
     #data = '"demo":"42"'
-    #mess = '{ "version":"1.1", "host":"host-test", "short_message":"CMT gelf test", ' + data + ' }'  
+    #mess = '{ "version":"1.1", "host":"host-test", "short_message":"CMT gelf test", ' + data + ' }'
 
 
     if cmt.ARGS['devmode']:
@@ -569,7 +570,7 @@ def graylog_send_udp_gelf(host, port=12201, data=""):
 class Persist():
     ''' Implement a persistent on-disk key/value structure, between cmt runs'''
 
-    def __init__(self, file = None):    
+    def __init__(self, file = None):
         self.file = file
         self.dict = {}
         self.load()
@@ -594,7 +595,7 @@ class Persist():
         data = ""
         try:
             with open(self.file,"r") as fi:
-                data=fi.read()            
+                data=fi.read()
         except:
             debug("ERROR - Persist() : couldn't read file {}".format(self.file))
         # decoding the JSON to dictionay
@@ -607,7 +608,7 @@ class Persist():
     def save(self):
 
         if not cmt.ARGS['persist']:
-            debug("Persist.save : disable (cli / no arg)")            
+            debug("Persist.save : disable (cli / no arg)")
             return
 
         debug("Persist.write() : ", self.file)
@@ -619,7 +620,7 @@ class Persist():
             debug("ERROR - Persist() : couldn't write file {}".format(self.file))
 
 
-    
+
 
 # ----------------------------------------------------------
 # Class CheckItem
@@ -657,7 +658,7 @@ class CheckItem():
         else:
             return ''
 
-    
+
 # ----------------------------------------------------------
 # Class Check
 # ----------------------------------------------------------
@@ -686,19 +687,19 @@ class Check():
         self.alert = 0
         self.warn = 0
         self.notice = 0
-        self.checkitems=[]    
+        self.checkitems=[]
 
         # set by framework after Check is performed, if pager_enable and alert>0
         self.pager = False
 
         # fields from conf
         self.conf = conf
-        
-        
+
+
         # persist values from previous run for same get_id()
         id = self.get_id()
         self.persist = cmt.PERSIST.get_key(id,{})
-        
+
         # compute alert_max_level
         self.alert_max_level = "alert"   # DEFAULT
         # check level ?
@@ -725,7 +726,7 @@ class Check():
 
     def add_item(self, item):
         ''' add a CheckItem instance to the Check items list '''
-        self.checkitems.append(item)          
+        self.checkitems.append(item)
 
     def get_id(self):
         ''' Returns unique check id '''
@@ -737,7 +738,7 @@ class Check():
         for mm in self.message:
             if len(v) > 0:
                 v = v + " ; "
-            v = v + mm 
+            v = v + mm
         return v
 
 
@@ -750,13 +751,13 @@ class Check():
 
         if level == "alert":
             return
-        
+
         if level == "warn":
             self.notice = self.warn
             self.warn = self.alert
             self.alert = 0
             return
-        
+
         if level == "notice":
             self.notice = self.alert
             self.alert = 0
@@ -773,21 +774,21 @@ class Check():
         # seconds for state transition normal to alert (if alert)
         alert_delay = conf_get_hysteresis(self)
 
-        hystpersist = cmt.PERSIST.get_key("hysteresis", {})        
+        hystpersist = cmt.PERSIST.get_key("hysteresis", {})
         id = self.get_id()
         hystpersist_item = hystpersist.get(id,{})
 
         hystlastrun = hystpersist_item.get('lastrun',0)
         now = int(time.time())
         delta = int ( now - hystlastrun )
-        
+
         duration_alert = hystpersist_item.get('duration_alert',0)
         oldstate = hystpersist_item.get('state','normal')
-        
+
         newstate = oldstate
 
         #print("Hysteresis", duration_alert, delta, alert_delay)
-        
+
         if self.alert > 0 :
             if oldstate == "normal":
                 duration_alert += delta
@@ -804,8 +805,8 @@ class Check():
             # adjust to warn ; not a transition
             self.adjust_alert_max_level("warn")
 
-        # write to Persist   
-        # lastrun   
+        # write to Persist
+        # lastrun
         # BUG
         hystpersist_item['lastrun'] = now
         hystpersist_item['duration_alert'] = duration_alert
@@ -830,18 +831,18 @@ class Check():
         print("{:12} {:10} {}".format(head, self.module, self.get_message_as_str()))
 
     def print_to_cli_detail(self):
-       
-        print()
-        print(bcolors.OKBLUE + bcolors.BOLD + "Check", self.module, bcolors.ENDC)        
 
-        for i in self.checkitems:    
+        print()
+        print(bcolors.OKBLUE + bcolors.BOLD + "Check", self.module, bcolors.ENDC)
+
+        for i in self.checkitems:
 
             v = str (i.value) + ' ' + str(i.unit) + ' (' + i.human() + ') '
             if len (i.description) > 0:
                 v = v + ' - ' + i.description
 
             print("cmt_{:18} {}".format(i.name, v))
-        
+
 
         head = bcolors.OKGREEN     + "OK     " + bcolors.ENDC
 
@@ -852,17 +853,17 @@ class Check():
         elif self.notice > 0:
             head = bcolors.OKBLUE  + "NOTICE " + bcolors.ENDC
 
-        print("{:31} {}".format(head, self.get_message_as_str()))        
+        print("{:31} {}".format(head, self.get_message_as_str()))
 
 
     def send_metrology(self):
-        
-        ''' Send Check results (event, multiple CheckItems) 
+
+        ''' Send Check results (event, multiple CheckItems)
             to metrology servers.
         '''
 
-        graylog_data = build_gelf_message(self)  
-        
+        graylog_data = build_gelf_message(self)
+
         for metro in cmt.CONF['metrology_servers']:
 
 
@@ -893,7 +894,7 @@ class Check():
 # ----------------------------------------------------------
 
 class Report():
-    
+
     '''A Report stores all the Checks from a single run of CMT.
        Pager alerts are sent to Pager targets at the end of the run.
     '''
@@ -968,7 +969,7 @@ class Report():
             debug("Pager  : disabled/inactive in global config.")
             return
 
-        # Find 'Alert' Pager         
+        # Find 'Alert' Pager
         if not 'alert' in cmt.CONF['pagers']:
             debug("No alert pager configured.")
             return
@@ -999,7 +1000,7 @@ class Report():
         origin = cmt.CONF['global']['cmt_group'] + '/' + cmt.CONF['global']['cmt_node']
         color = "FF0000"
         title = "ALERT from " + origin
-        
+
         message = ""
         for c in self.checks:
                 if c.alert > 0:
@@ -1016,8 +1017,8 @@ class Report():
                     message += '<br>\n'
 
 
-        debug("Pager Message : ",message)              
-        
+        debug("Pager Message : ",message)
+
         # send alert
         r = teams_send(url=url, title=title, message=message ,color=color, origin=origin)
         if r == 200:

--- a/docs/docs/check_certificate.md
+++ b/docs/docs/check_certificate.md
@@ -1,0 +1,9 @@
+## Enable the module
+
+### Add a check
+
+    certificate_db:
+      module: certificate
+      hostname: google.com
+      port: 2718                 # defaults to 443 if not specified
+      alert_expires_in: 1 week

--- a/docs/docs/check_certificate.md
+++ b/docs/docs/check_certificate.md
@@ -1,5 +1,5 @@
 Opens a socket to `hostname:port` and retrieve certificate information (with
-`.getpeercert()`).
+[`ssl.SSLSocket.getpeercert()`](https://docs.python.org/3/library/ssl.html#ssl.SSLSocket.getpeercert)).
 
 ### Add a check
 
@@ -9,20 +9,22 @@ Opens a socket to `hostname:port` and retrieve certificate information (with
       port: 2718                 # defaults to 443 if not specified
       alert_expires_in: 1 week
 
+hostname (string) and port (integer):
 
-- `hostname`: the hostname
-- `port`: the port to connect the socket to
-- `alert_expires_in`: [`<duration>`](duration.md), sends an alert if
-  expiry date (`notAfter` field) is less that `<duration>` away.
+    the hostname:port pair to connect the socket to
+
+alert_expires_in ([`duration`](duration.md)):
+
+    sends an alert if expiry date (`notAfter` field) is less that <duration> away.
 
 ## Alerts
 
-Sends an alert if a certificate is invalid, that is, one of these condition
+Sends an alert if a certificate is invalid, that is, one of these conditions
 matches:
 
 1. `expiry date - now < alert_expires_in`
-2. `now < notBefore` (notBefore is the timestamp at which the certificate will
-   become valid)
+2. `now < notBefore` (notBefore is the timestamp at which the certificate
+   becomes valid)
 3. No certificate is found
 4. The connection to `hostname:port` can't be established.
 

--- a/docs/docs/check_certificate.md
+++ b/docs/docs/check_certificate.md
@@ -12,7 +12,7 @@ Opens a socket to `hostname:port` and retrieve certificate information (with
 
 - `hostname`: the hostname
 - `port`: the port to connect the socket to
-- `alert_expires_in`: [`<duration>`](/docs/duration.md), sends an alert if
+- `alert_expires_in`: [`<duration>`](duration.md), sends an alert if
   expiry date (`notAfter` field) is less that `<duration>` away.
 
 ## Alerts

--- a/docs/docs/check_certificate.md
+++ b/docs/docs/check_certificate.md
@@ -1,9 +1,40 @@
-## Enable the module
+Opens a socket to `hostname:port` and retrieve certificate information (with
+`.getpeercert()`).
 
 ### Add a check
 
     certificate_db:
       module: certificate
-      hostname: google.com
+      hostname: hostname.com
       port: 2718                 # defaults to 443 if not specified
       alert_expires_in: 1 week
+
+
+- `hostname`: the hostname
+- `port`: the port to connect the socket to
+- `alert_expires_in`: [`<duration>`](/docs/duration.md), sends an alert if
+  expiry date (`notAfter` field) is less that `<duration>` away.
+
+## Alerts
+
+Sends an alert if a certificate is invalid, that is, one of these condition
+matches:
+
+1. `expiry date - now < alert_expires_in`
+2. `now < notBefore` (notBefore is the timestamp at which the certificate will
+   become valid)
+3. No certificate is found
+4. The connection to `hostname:port` can't be established.
+
+
+## Output to ElasticSearch
+
+    cmt_certificate_hostname                 string
+    cmt_certificate_port                     int
+    certificate_expires_in                   int (seconds)
+
+    certificate_issuer_common_name           string
+    certificate_issuer_organization_name     string
+
+    certificate_subject_common_name          string
+    certificate_subject_organization_name    string

--- a/docs/docs/duration.md
+++ b/docs/docs/duration.md
@@ -1,0 +1,32 @@
+## Duration
+
+    duration = quantifier space unit space quantifier space unit ...
+
+    quantifier = positive integer (0, 1, 2, ...)
+    unit       = "hour", "day", "week", "month", "year"
+
+    Units may have an extra "s" at the end.
+
+A month is 30 days, and a year is 365 days, always.
+
+### Examples
+
+    1 day 3 hours
+    2 weeks
+    3 years 2 month 1 day 23 hours
+    50 hours
+    1 hour 3 days
+
+These are invalid:
+
+    1 day 2           what is the unit for 2?
+    2 day 3 day       duplicate units not allowed
+    2 day -1 hour     negatives not allowed
+    2hours            space required
+    3 foo             invalid unit
+
+Equivalence:
+
+    1 day    == 24 hours
+    1 month  == 30 days
+    1 year   == 365 days

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -19,7 +19,7 @@ nav:
 #  - 'FAQ': 'faq.md'
   - 'CLI': 'cli.md'
   - 'Cron / Automatic run' : 'cron.md'
-  - 'Checks': 
+  - 'Checks':
       - 'load': 'check_load.md'
       - 'cpu': 'check_cpu.md'
       - 'memory': 'check_memory.md'
@@ -31,6 +31,9 @@ nav:
       - 'urls': 'check_urls.md'
       - 'folders': 'check_folders.md'
       - 'pings': 'check_pings.md'
+      - certificate: check_certificate.md
+  - 'Custom formats':
+    - Duration: duration.md
   - 'Data model' : 'data_model.md'
 #  - 'Dev / How to extend': 'extend.md'
   - 'License': license.md
@@ -57,4 +60,3 @@ markdown_extensions:
   - pymdownx.emoji:
       emoji_index: !!python/name:materialx.emoji.twemoji
       emoji_generator: !!python/name:materialx.emoji.to_svg
-      

--- a/helpers.py
+++ b/helpers.py
@@ -4,8 +4,8 @@ import datetime
 def parse_duration(string):
     """parse something like "1 day 2 hours".
 
-    Units can be singular or plural. Supported units are days, months, weeks and hours. A
-    months is equivalent to 30 days.
+    Units can be singular or plural. Supported units are years, months, weeks, days and
+    hours. A months is equivalent to 30 days. A year is 365 days.
 
     Negatives values aren't supported.
     """
@@ -22,7 +22,11 @@ def parse_duration(string):
                 quantifier = int(word)
             except ValueError:
                 # for better context (both exceptions will be printed though)
-                raise ValueError("Failed parsing duration {!r}".format(string))
+                raise ValueError(
+                    "failed parsing quantifier {!r} in duration {!r}".format(
+                        word, string
+                    )
+                )
 
             if quantifier < 0:
                 raise ValueError("don't use negative values {!r}".format(string))
@@ -32,7 +36,7 @@ def parse_duration(string):
             if not word.endswith("s"):
                 word += "s"
 
-            if word not in ("weeks", "days", "months", "hours"):
+            if word not in ("years", "weeks", "days", "months", "hours"):
                 raise ValueError("invalid unit {!r} in {!r}".format(word, string))
 
             if word in kwargs:
@@ -49,10 +53,15 @@ def parse_duration(string):
             )
         )
 
-    # dealing with the variations in the number of days of each months would be an
+    # dealing with the variations in the number of days of each months/year would be an
     # overkill here
+
     if "months" in kwargs:
         kwargs["days"] = kwargs.get("days", 0) + 30 * kwargs["months"]
         del kwargs["months"]
+
+    if "years" in kwargs:
+        kwargs["days"] = kwargs.get("days", 0) + 365 * kwargs["years"]
+        del kwargs["years"]
 
     return datetime.timedelta(**kwargs)

--- a/helpers.py
+++ b/helpers.py
@@ -1,0 +1,58 @@
+import datetime
+
+
+def parse_duration(string):
+    """parse something like "1 day 2 hours".
+
+    Units can be singular or plural. Supported units are days, months, weeks and hours. A
+    months is equivalent to 30 days.
+
+    Negatives values aren't supported.
+    """
+
+    if string.strip() == "":
+        raise ValueError("duration cannot be just empty space {!r}", string)
+
+    words = string.split(" ")
+    kwargs = {}
+    quantifier = None
+    for i, word in enumerate(words):
+        if i % 2 == 0:
+            try:
+                quantifier = int(word)
+            except ValueError:
+                # for better context (both exceptions will be printed though)
+                raise ValueError("Failed parsing duration {!r}".format(string))
+
+            if quantifier < 0:
+                raise ValueError("don't use negative values {!r}".format(string))
+
+        else:
+            # it's a unit
+            if not word.endswith("s"):
+                word += "s"
+
+            if word not in ("weeks", "days", "months", "hours"):
+                raise ValueError("invalid unit {!r} in {!r}".format(word, string))
+
+            if word in kwargs:
+                raise ValueError("unit {!r} already used in {!r}".format(word, string))
+
+            kwargs[word] = quantifier
+
+            quantifier = None
+
+    if quantifier is not None:
+        raise ValueError(
+            "unit expected for the last quantifier {!r} in {!r}".format(
+                quantifier, string
+            )
+        )
+
+    # dealing with the variations in the number of days of each months would be an
+    # overkill here
+    if "months" in kwargs:
+        kwargs["days"] = kwargs.get("days", 0) + 30 * kwargs["months"]
+        del kwargs["months"]
+
+    return datetime.timedelta(**kwargs)

--- a/helpers.py
+++ b/helpers.py
@@ -2,7 +2,7 @@ import datetime
 
 
 def parse_duration(string):
-    """parse something like "1 day 2 hours".
+    """parse a duration like "1 day 2 hours".
 
     Units can be singular or plural. Supported units are years, months, weeks, days and
     hours. A months is equivalent to 30 days. A year is 365 days.

--- a/tests/test_parse_duration.py
+++ b/tests/test_parse_duration.py
@@ -1,0 +1,64 @@
+import pytest
+import datetime
+
+from helpers import parse_duration
+
+
+def test_examples():
+    assert parse_duration("1 week 2 days") == datetime.timedelta(days=7 + 2)
+    assert parse_duration("1 month 2 weeks") == datetime.timedelta(days=30 + 2 * 7)
+    assert parse_duration("12 hours") == datetime.timedelta(hours=12)
+
+    assert parse_duration("1 hour 8 days") == datetime.timedelta(hours=1, days=8)
+    assert parse_duration("1 hours 8 days") == datetime.timedelta(hours=1, days=8)
+
+    with pytest.raises(ValueError):
+        parse_duration("1 hour 2 hour")
+
+    with pytest.raises(ValueError):
+        parse_duration("1 invalidunit")
+
+    with pytest.raises(ValueError):
+        parse_duration("1 invalidunits")
+
+    with pytest.raises(ValueError):
+        parse_duration("hour 2")
+
+    with pytest.raises(ValueError):
+        parse_duration("2hours")
+
+    with pytest.raises(ValueError):
+        parse_duration("2 hours 3")
+
+    with pytest.raises(ValueError):
+        parse_duration("-2 hours")
+
+    assert parse_duration("24 hours") == parse_duration("1 day")
+
+
+def test_simple_durations():
+    assert parse_duration("1 month") == datetime.timedelta(days=30)
+    assert parse_duration("2 month") == datetime.timedelta(days=2 * 30)
+    assert parse_duration("1 months") == datetime.timedelta(days=30)
+    assert parse_duration("2 months") == datetime.timedelta(days=2 * 30)
+
+    assert parse_duration("1 week") == datetime.timedelta(days=7)
+    assert parse_duration("2 week") == datetime.timedelta(days=14)
+    assert parse_duration("1 weeks") == datetime.timedelta(days=7)
+    assert parse_duration("2 weeks") == datetime.timedelta(days=14)
+
+    assert parse_duration("1 hour") == datetime.timedelta(hours=1)
+    assert parse_duration("2 hour") == datetime.timedelta(hours=2)
+    assert parse_duration("1 hours") == datetime.timedelta(hours=1)
+    assert parse_duration("2 hours") == datetime.timedelta(hours=2)
+
+    assert parse_duration("1 day") == datetime.timedelta(days=1)
+    assert parse_duration("2 day") == datetime.timedelta(days=2)
+    assert parse_duration("1 days") == datetime.timedelta(days=1)
+    assert parse_duration("2 days") == datetime.timedelta(days=2)
+
+
+def test_composite():
+    assert parse_duration("3 month 78 weeks 12 days 314 hours") == datetime.timedelta(
+        days=3 * 30 + 78 * 7 + 12, hours=314
+    )

--- a/tests/test_parse_duration.py
+++ b/tests/test_parse_duration.py
@@ -57,8 +57,13 @@ def test_simple_durations():
     assert parse_duration("1 days") == datetime.timedelta(days=1)
     assert parse_duration("2 days") == datetime.timedelta(days=2)
 
+    assert parse_duration("1 year") == datetime.timedelta(days=1 * 365)
+    assert parse_duration("2 year") == datetime.timedelta(days=2 * 365)
+    assert parse_duration("1 years") == datetime.timedelta(days=1 * 365)
+    assert parse_duration("2 years") == datetime.timedelta(days=2 * 365)
+
 
 def test_composite():
-    assert parse_duration("3 month 78 weeks 12 days 314 hours") == datetime.timedelta(
-        days=3 * 30 + 78 * 7 + 12, hours=314
+    assert parse_duration("27 years 3 month 78 weeks 12 days 314 hours") == datetime.timedelta(
+        days=27 * 365 + 3 * 30 + 78 * 7 + 12, hours=314
     )


### PR DESCRIPTION
1. `cmt.py`, `cmt_global.py` and `cmt_shared.py` have a lot of meaningless diff: just some white spaces my editor stripped automatically.

2. To run the tests (first, make sure to `pip install pytest`):

```bash
~/code/cavaliba/cmt_monitor $ python -m pytest
```

3. I didn't put the function `parse_duration` in `cmt_shared` because it caused a circular import loop when running the tests. A better file structure should be used.

<details>
<summary>circular import</summary>

```
Traceback:                                                                                                                                                                                                 
/usr/lib/python3.8/importlib/__init__.py:127: in import_module                                                                                                                                             
    return _bootstrap._gcd_import(name[level:], package, level)                                                                                                                                            
tests/test_parse_duration.py:5: in <module>                                                                                                                                                                
    from cmt_shared import parse_duration                                                                                                                                                                  
cmt_shared.py:18: in <module>                                                                                                                                                                              
    import cmt_globals as cmt                                                                                                                                                                              
cmt_globals.py:10: in <module>                                                                                                                                                                             
    from checks.load import check_load                                                                                                                                                                     
checks/load.py:5: in <module>                                                                                                                                                                              
    from cmt_shared import Check, CheckItem                                                                                                                                                                
E   ImportError: cannot import name 'Check' from partially initialized module 'cmt_shared' (most likely due to a circular import) (/home/math2001/code/cavaliba/cmt_monitor/cmt_shared.py) 
```

</details>

4. I added some documentation for `check_certificate` and the `duration` format.

```yaml
---

global:
  cmt_group: dev
  cmt_node: dev
  enable: yes

checks:
  google:
    module: certificate
    hostname: google.com
    alert_expires_in: 6 months 3 days

  duck:
    module: certificate
    hostname: duckduckgo.com
    alert_expires_in: 1 week

  broken:
    module: certificate
    hostname: duckduckgo.com
    port: 80
    alert_expires_in: 2 week
```

```
$ python cmt.py certificate
------------------------------------------------------------
CMT - Version 1.0.0 - (c) Cavaliba.com - 2020/11/29
------------------------------------------------------------
2020/12/05 - 19:50:36 : Starting ...
cmt_group      :  dev
cmt_node       :  dev


Check certificate
cmt_certificate_hostname google.com  ()  - Hostname
cmt_certificate_port   443  ()  - Port
cmt_certificate_expires_in 4488185 seconds (51 days, 22:43:05)
cmt_certificate_issuer_common_name GTS CA 1O1  ()
cmt_certificate_issuer_organization_name Google Trust Services  ()
cmt_certificate_subject_common_name *.google.com  ()
cmt_certificate_subject_organization_name Google LLC  ()
NOK                    hostname: google.com:443 - certificate will expire soon (in 51 days, 22:43:04.839822)

Check certificate
cmt_certificate_hostname duckduckgo.com  ()  - Hostname
cmt_certificate_port   443  ()  - Port
cmt_certificate_expires_in 29344163 seconds (339 days, 15:09:23)
cmt_certificate_issuer_common_name DigiCert SHA2 Secure Server CA  ()
cmt_certificate_issuer_organization_name DigiCert Inc  ()
cmt_certificate_subject_common_name *.duckduckgo.com  ()
cmt_certificate_subject_organization_name Duck Duck Go, Inc.  ()
OK

Check certificate
cmt_certificate_hostname duckduckgo.com  ()  - Hostname
cmt_certificate_port   80  ()  - Port
NOK                    hostname duckduckgo.com:80 - no certificate found no ssl connection ([SSL: WRONG_VERSION_NUMBER] wrong version number (_ssl.c:1123))

Notification Summary
--------------------

No notice

No warnings

Alerts
certificate     : hostname: google.com:443 - certificate will expire soon (in 51 days, 22:43:04.839822)
certificate     : hostname duckduckgo.com:80 - no certificate found no ssl connection ([SSL: WRONG_VERSION_NUMBER] wrong version number (_ssl.c:1123))

2020/12/05 - 19:50:37 : Done.
```